### PR TITLE
Document unknown USB packets and extended header quirk

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,6 @@ This is a reverse-engineering project. Contributions are welcome for:
 ## Disclaimer
 
 This is an unofficial reverse-engineering effort. Use at your own risk. The author is not affiliated with ChargerLAB. 
+## TODO
+- Handle PutData packets that include ExtendedHeader despite extend flag being 0.
+- Investigate interrupt transfer packets (0x01) with 8-byte payloads; format currently unknown.

--- a/docs/pcap_analysis.md
+++ b/docs/pcap_analysis.md
@@ -1,0 +1,22 @@
+# KM003C PCAP Analysis
+
+This file documents observations from parsing `pd_capture_new.9.pcapng` using `tshark`.
+
+## Observed Frames
+- Bulk transfers (transfer_type `0x03`) carry the main protocol data on endpoints `0x01` (H->D) and `0x81` (D->H).
+- Host repeatedly sends `GetData` commands with attribute `AdcQueue` (`0x02`). Example hex frame:
+  - `0cd00200` (frame 7) → `packet_type=0x0C`, id `0xD0`.
+- Device responds with `PutData` packets containing 44 byte ADC payloads. These packets start with bytes such as `41d08202…`.
+
+## Extended Header
+For `PutData` responses the first payload dword decodes as:
+- `attribute = 0x0001` (`Adc`)
+- `next = 0`
+- `chunk = 0`
+- `size = 44`
+
+This matches the size of the embedded `AdcDataRaw` structure.
+Notably the `extend` flag inside the packet header is **zero**, yet the extended header is always present. Parsing code should not rely on that flag.
+
+## Unknown Interrupt Packets
+Several interrupt transfers (`transfer_type 0x01`) on endpoint `0x81` contain 8 bytes of data such as `0800000000000000` or `0900000000000000`. Their purpose is currently unknown.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -192,6 +192,8 @@ The device may return error responses or fail to respond within the timeout peri
 - Firmware update protocol not analyzed
 - Advanced measurement modes may isn't reversed yet
 - Some proprietary features may use undocumented packet types
+### Unknown Packet Types
+- Interrupt transfer packets (endpoint 0x81, transfer_type 0x01) with 8-byte payloads like `0800000000000000`. Structure not yet decoded.
 
 ## References
 


### PR DESCRIPTION
## Summary
- note inconsistent `extend` flag behavior and interrupt packet format in README and protocol docs
- add new pcap analysis notes

## Testing
- `tshark -r pd_analisys/pd_capture_new.9.pcapng -Y "usb.transfer_type == 0x03" -T fields -e frame.number -e usb.endpoint_address -e usb.capdata | head`
- `python3` scripts to decode headers

------
https://chatgpt.com/codex/tasks/task_e_6887c11a2cb4832faaa73ec1d75ee0bf