### PR TITLE
lib: fix chained `AdcQueue` payload parsing

### DIFF
--- a/km003c-lib/src/packet.rs
+++ b/km003c-lib/src/packet.rs
@@ -444,9 +444,15 @@ impl TryFrom<Bytes> for RawPacket {
                         .map_err(|_| KMError::InvalidPacket("Failed to extract extended header bytes".to_string()))?;
                     let ext = ExtendedHeader::from_bytes(ext_header_array);
 
-                    let payload_size = ext.size() as usize;
                     let has_next = ext.next();
                     let attribute = Attribute::from_primitive(ext.attribute());
+                    // AdcQueue uses chunk as its sample count and size as bytes per sample.
+                    let payload_size = ext.size() as usize
+                        * if attribute == Attribute::AdcQueue {
+                            ext.chunk() as usize
+                        } else {
+                            1
+                        };
 
                     // For AdcQueue, the size field indicates sample size (20 bytes),
                     // but the actual payload contains multiple samples.

--- a/km003c-lib/tests/adcqueue_tests.rs
+++ b/km003c-lib/tests/adcqueue_tests.rs
@@ -64,6 +64,19 @@ fn test_adcqueue_parsing() {
 }
 
 #[test]
+fn test_adcqueue_with_following_pd_status() {
+    // Main header + AdcQueue header + 2 samples + PD header + PD status.
+    let hex = "410a420302800205ae3f0600b0ec300170cd1800ee01c706c900c500\
+               af3f0600b0ec300170cd1800ee01c606c500ba0010000003\
+               b43f0600074e0e08ef01c606";
+    let raw_packet = RawPacket::try_from(Bytes::from(hex::decode(hex).unwrap())).unwrap();
+    let packet = Packet::try_from(raw_packet).unwrap();
+
+    assert_eq!(packet.get_adc_queue().unwrap().samples.len(), 2);
+    assert!(packet.get_pd_status().is_some());
+}
+
+#[test]
 fn test_adcqueue_sequence_check() {
     // Create test data with sequence gap
     let mut raw_bytes = vec![0u8; 40]; // 2 samples


### PR DESCRIPTION
## summary

- use `ExtendedHeader::chunk` as the sample count when calculating `AdcQueue` payload size
- preserve the following pd payload in combined `AdcQueue` and `PdPacket` responses
- add a regression test covering multiple adc samples followed by pd status

## problem

`ExtendedHeader::size` describes the size of one adc sample. when an `AdcQueue` response was followed by another logical packet, the parser consumed only one sample and interpreted the next sample as a header.
