### PR TITLE
Create draft GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,4 +147,5 @@ jobs:
         with:
           files: release-assets/*
           generate_release_notes: true
+          draft: true
           fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary

Create tag-triggered GitHub Releases as drafts so they can be reviewed and published manually.

## Validation

- `actionlint .github/workflows/release.yml`