### PR TITLE
Share USB PD decoding and stabilize connection status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,8 +1909,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uom",
- "usbpd",
 ]
 
 [[package]]
@@ -1923,8 +1921,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uom",
- "usbpd",
 ]
 
 [[package]]
@@ -1946,6 +1942,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uom",
+ "usbpd",
  "zerocopy",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ tokio = { version = "1.53.0", features = ["full"] }
 tracing = "0.1.44"
 tracing-subscriber = "0.3.23"
 uom = "0.36"
-usbpd = { git = "https://github.com/okhsunrog/usbpd", rev = "b5dd12e" }
+usbpd = { version = "2.0.0", git = "https://github.com/okhsunrog/usbpd", rev = "b5dd12e" }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Core library providing:
 - Streaming authentication (required for AdcQueue)
 - ADC and AdcQueue data parsing
 - USB PD event parsing
+- Optional stateful USB PD semantic decoding through the `usbpd` feature
 
 ### `km003c-cli`
 Command-line tools:
@@ -76,7 +77,7 @@ suffixes such as `vbus_v`, `ibus_a`, and `power_w`.
 ## Quick Start
 
 ### Prerequisites
-- Rust 1.92+ (the library and CLI support Rust 1.89+)
+- Rust 1.97+
 - USB access permissions (udev rules on Linux)
 - POWER-Z KM003C device
 
@@ -188,7 +189,7 @@ This implementation is based on reverse engineering documented at:
 **[km003c-protocol-research](https://github.com/okhsunrog/km003c-protocol-research)**
 
 The research repository contains:
-- Complete protocol specification
+- A capture-backed protocol reference and an explicit list of remaining gaps
 - USB transport documentation
 - PCAPNG captures and analysis tools
 - Firmware analysis notes

--- a/km003c-cli/Cargo.toml
+++ b/km003c-cli/Cargo.toml
@@ -10,11 +10,8 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-km003c-lib.workspace = true
+km003c-lib = { workspace = true, features = ["usbpd"] }
 tokio.workspace = true
 clap = { version = "4.6.2", features = ["derive"] }
 tracing-subscriber.workspace = true
 tracing.workspace = true
-usbpd.workspace = true
-# Keep this aligned with usbpd's public quantity types.
-uom.workspace = true

--- a/km003c-cli/src/bin/test_usbpd.rs
+++ b/km003c-cli/src/bin/test_usbpd.rs
@@ -1,423 +1,44 @@
-use clap::Parser;
-use km003c_lib::{DeviceConfig, KM003C, Packet, pd::PdEventData};
 use std::time::{Duration, Instant};
-use usbpd::protocol_layer::message::data::source_capabilities::{Augmented, PowerDataObject, SourceCapabilities};
-use usbpd::protocol_layer::message::data::{self, Data};
-use usbpd::protocol_layer::message::extended::Extended;
-use usbpd::protocol_layer::message::extended::chunked::{ChunkResult, ChunkedMessageAssembler};
-use usbpd::protocol_layer::message::header::ExtendedMessageType;
-use usbpd::protocol_layer::message::{Message, ParseError, Payload};
 
-/// USB PD negotiation capture for POWER-Z KM003C
+use clap::Parser;
+use km003c_lib::pd::PdEventData;
+use km003c_lib::uom::si::electric_current::ampere;
+use km003c_lib::uom::si::electric_potential::volt;
+use km003c_lib::uom::si::power::watt;
+use km003c_lib::uom::si::time::millisecond;
+use km003c_lib::usbpd::protocol_layer::message::Payload;
+use km003c_lib::usbpd::protocol_layer::message::data::source_capabilities::{
+    Augmented, PowerDataObject, SourceCapabilities,
+};
+use km003c_lib::usbpd::protocol_layer::message::data::{self, Data};
+use km003c_lib::usbpd::protocol_layer::message::extended::Extended;
+use km003c_lib::{
+    DecodedPdEvent, DecodedPdMessage, DeviceConfig, KM003C, Packet, PdChunkState, PdChunkStatus, PdDecodeFailure,
+    PdSessionDecoder,
+};
+
+/// USB PD negotiation capture for POWER-Z KM003C.
 ///
-/// Note: PD capture only works reliably with the vendor interface.
-/// HID interface causes device crashes when attempting PD operations.
+/// PD capture only works reliably with the vendor interface. The HID interface
+/// can crash the device when attempting PD operations.
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    /// Skip USB reset (defaults to true on macOS for compatibility)
+    /// Skip USB reset (defaults to true on macOS for compatibility).
     #[arg(long, default_value_t = cfg!(target_os = "macos"))]
     no_reset: bool,
 
-    /// Force USB reset even on macOS (overrides --no-reset)
+    /// Force USB reset even on macOS (overrides --no-reset).
     #[arg(long)]
     reset: bool,
 
-    /// Capture duration in seconds
+    /// Capture duration in seconds.
     #[arg(short, long, default_value = "20")]
     duration: u64,
 
-    /// Show raw bytes for each message
+    /// Show raw bytes for each message.
     #[arg(long)]
     raw: bool,
-}
-
-// Use uom for nice formatting
-use km003c_lib::uom::si::time::millisecond as km003c_millisecond;
-use uom::si::electric_current::ampere;
-use uom::si::electric_potential::volt;
-use uom::si::power::watt;
-
-/// Format a single PDO for display
-fn format_pdo(pdo: &PowerDataObject) -> String {
-    match pdo {
-        PowerDataObject::FixedSupply(f) => {
-            let v = f.voltage().get::<volt>();
-            let i = f.max_current().get::<ampere>();
-            let p = v * i;
-            let mut flags = Vec::new();
-            if f.dual_role_power() {
-                flags.push("DRP");
-            }
-            if f.usb_communications_capable() {
-                flags.push("USB");
-            }
-            if f.dual_role_data() {
-                flags.push("DRD");
-            }
-            if f.unconstrained_power() {
-                flags.push("UP");
-            }
-            if f.epr_mode_capable() {
-                flags.push("EPR");
-            }
-            let flags_str = if flags.is_empty() {
-                String::new()
-            } else {
-                format!(" [{}]", flags.join(","))
-            };
-            format!("Fixed {:.0}V @ {:.1}A ({:.0}W){}", v, i, p, flags_str)
-        }
-        PowerDataObject::Battery(b) => {
-            let min_v = b.min_voltage().get::<volt>();
-            let max_v = b.max_voltage().get::<volt>();
-            let p = b.max_power().get::<watt>();
-            format!("Battery {:.0}-{:.0}V @ {:.0}W", min_v, max_v, p)
-        }
-        PowerDataObject::VariableSupply(v) => {
-            let min_v = v.min_voltage().get::<volt>();
-            let max_v = v.max_voltage().get::<volt>();
-            let i = v.max_current().get::<ampere>();
-            format!("Variable {:.0}-{:.0}V @ {:.1}A", min_v, max_v, i)
-        }
-        PowerDataObject::Augmented(aug) => match aug {
-            Augmented::Spr(pps) => {
-                let min_v = pps.min_voltage().get::<volt>();
-                let max_v = pps.max_voltage().get::<volt>();
-                let i = pps.max_current().get::<ampere>();
-                let p = max_v * i;
-                let limited = if pps.pps_power_limited() { " (limited)" } else { "" };
-                format!("PPS {:.1}-{:.1}V @ {:.1}A ({:.0}W){}", min_v, max_v, i, p, limited)
-            }
-            Augmented::Epr(avs) => {
-                let min_v = avs.min_voltage().get::<volt>();
-                let max_v = avs.max_voltage().get::<volt>();
-                let p = avs.pd_power().get::<watt>();
-                format!("EPR AVS {:.0}-{:.0}V @ {:.0}W", min_v, max_v, p)
-            }
-            Augmented::Unknown(raw) => {
-                format!("Augmented(0x{:08X})", raw)
-            }
-        },
-        PowerDataObject::Unknown(u) => {
-            format!("Unknown(0x{:08X})", u.0)
-        }
-    }
-}
-
-/// Print source capabilities in a nice format
-fn print_capabilities(caps: &[PowerDataObject], title: &str) {
-    println!("             [{}]", title);
-    for (i, pdo) in caps.iter().enumerate() {
-        // Skip null PDOs (separator between SPR and EPR)
-        if matches!(pdo, PowerDataObject::FixedSupply(f) if f.0 == 0) {
-            println!("             PDO[{}]: --- (separator) ---", i + 1);
-        } else {
-            println!("             PDO[{}]: {}", i + 1, format_pdo(pdo));
-        }
-    }
-}
-
-struct PdDecoder {
-    source_caps: Option<SourceCapabilities>,
-    /// Assembler for chunked EPR Source Capabilities
-    epr_assembler: ChunkedMessageAssembler,
-    /// Whether to show raw bytes
-    show_raw: bool,
-}
-
-impl PdDecoder {
-    fn new(show_raw: bool) -> Self {
-        Self {
-            source_caps: None,
-            epr_assembler: ChunkedMessageAssembler::new(),
-            show_raw,
-        }
-    }
-
-    fn handle_connect(&mut self) {
-        self.source_caps = None;
-        self.epr_assembler.reset();
-    }
-
-    fn decode(&mut self, timestamp_ms: u32, sop: u8, wire_data: &[u8]) {
-        if wire_data.is_empty() {
-            return;
-        }
-
-        let ts = timestamp_ms as f64 / 1000.0;
-
-        // Print raw bytes if enabled
-        if self.show_raw {
-            print!("[{:>8.3}s] RAW[{}]: ", ts, wire_data.len());
-            for (i, byte) in wire_data.iter().enumerate() {
-                if i > 0 && i % 16 == 0 {
-                    print!("\n                     ");
-                }
-                print!("{:02X} ", byte);
-            }
-            println!();
-        }
-
-        match Message::from_bytes(wire_data) {
-            Ok(msg) => {
-                let msg_type = msg.header.message_type();
-                let msg_id = msg.header.message_id();
-                let role = format!("{:?}/{:?}", msg.header.port_power_role(), msg.header.port_data_role());
-
-                let type_str = format!("{:?}", msg_type);
-                println!(
-                    "[{:>8.3}s] SOP{}: {:<20} (ID={}, ROLE={})",
-                    ts, sop, type_str, msg_id, role
-                );
-
-                match &msg.payload {
-                    Some(Payload::Data(data)) => match data {
-                        Data::SourceCapabilities(caps) => {
-                            self.source_caps = Some(caps.clone());
-                            print_capabilities(caps.pdos(), "SPR Source Capabilities");
-                        }
-                        Data::Request(req) => {
-                            self.print_request(req);
-                        }
-                        Data::EprMode(mode) => {
-                            println!("             EPR Mode: {:?}", mode);
-                        }
-                        Data::Unknown => {
-                            println!("             Unknown Data Message");
-                        }
-                        _ => {
-                            println!("             Data: {:?}", data);
-                        }
-                    },
-                    Some(Payload::Extended(ext)) => match ext {
-                        Extended::EprSourceCapabilities(pdos) => {
-                            print_capabilities(pdos.as_slice(), "EPR Source Capabilities");
-                        }
-                        Extended::ExtendedControl(ctrl) => {
-                            println!(
-                                "             Extended Control: {:?} (data=0x{:02X})",
-                                ctrl.message_type(),
-                                ctrl.data()
-                            );
-                        }
-                        _ => {
-                            println!("             Extended: {:?}", ext);
-                        }
-                    },
-                    None => {
-                        // Control message (GoodCRC, Accept, etc.) - already summarized by type_str
-                    }
-                }
-            }
-            Err(ParseError::ChunkedExtendedMessage {
-                chunk_number,
-                data_size,
-                request_chunk,
-                message_type,
-            }) => {
-                // Handle chunked extended messages
-                if request_chunk {
-                    // This is a chunk request - just log it
-                    println!(
-                        "[{:>8.3}s] SOP{}: Chunk Request (chunk={}, type={:?})",
-                        ts, sop, chunk_number, message_type
-                    );
-                    return;
-                }
-
-                // Only handle EPR Source Capabilities for now
-                if message_type != ExtendedMessageType::EprSourceCapabilities {
-                    println!(
-                        "[{:>8.3}s] SOP{}: Chunked {:?} (chunk {}/{} bytes) - not assembled",
-                        ts, sop, message_type, chunk_number, data_size
-                    );
-                    return;
-                }
-
-                // Parse chunk and feed to assembler
-                match Message::parse_extended_chunk(wire_data) {
-                    Ok((header, ext_header, chunk_data)) => {
-                        match self.epr_assembler.process_chunk(header, ext_header, chunk_data) {
-                            Ok(ChunkResult::Complete(assembled_data)) => {
-                                // Parse the assembled EPR Source Capabilities
-                                let ext = Message::parse_extended_payload(
-                                    ExtendedMessageType::EprSourceCapabilities,
-                                    &assembled_data,
-                                );
-
-                                if let Extended::EprSourceCapabilities(pdos) = ext {
-                                    let msg_id = header.message_id();
-                                    let role = format!("{:?}/{:?}", header.port_power_role(), header.port_data_role());
-                                    println!(
-                                        "[{:>8.3}s] SOP{}: Extended(EprSourceCapabilities) (ID={}, ROLE={})",
-                                        ts, sop, msg_id, role
-                                    );
-                                    let title =
-                                        format!("EPR Source Capabilities - {} chunks assembled", chunk_number + 1);
-                                    print_capabilities(pdos.as_slice(), &title);
-                                }
-                            }
-                            Ok(ChunkResult::NeedMoreChunks(next)) => {
-                                println!(
-                                    "[{:>8.3}s] SOP{}: EPR Source Caps chunk {} received, waiting for chunk {}...",
-                                    ts, sop, chunk_number, next
-                                );
-                            }
-                            Ok(ChunkResult::ChunkRequested(num)) => {
-                                println!("[{:>8.3}s] SOP{}: Chunk {} requested", ts, sop, num);
-                            }
-                            Err(e) => {
-                                println!("[{:>8.3}s] SOP{}: Chunk assembly error: {:?}", ts, sop, e);
-                                self.epr_assembler.reset();
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        println!("[{:>8.3}s] SOP{}: Failed to parse chunk: {:?}", ts, sop, e);
-                    }
-                }
-            }
-            Err(e) => {
-                println!(
-                    "[{:>8.3}s] SOP{}: Failed to parse: {:?} (Hex: {:02X?})",
-                    ts, sop, e, wire_data
-                );
-            }
-        }
-    }
-
-    fn print_request(&self, req: &data::request::PowerSource) {
-        use data::request::PowerSource;
-
-        match req {
-            PowerSource::FixedVariableSupply(p) => {
-                let curr = p.operating_current().get::<ampere>();
-                let max_curr = p.max_operating_current().get::<ampere>();
-                let pos = p.object_position();
-
-                // Look up Voltage from PDO if available
-                let pdo_info = self
-                    .source_caps
-                    .as_ref()
-                    .and_then(|caps| caps.pdos().get(pos as usize - 1))
-                    .map(format_pdo);
-
-                if let Some(info) = pdo_info {
-                    println!("             RDO: PDO#{} ({}) @ {:.1}A", pos, info, curr);
-                } else {
-                    println!("             RDO: PDO#{} @ {:.1}A (Max {:.1}A)", pos, curr, max_curr);
-                }
-            }
-            PowerSource::Battery(p) => {
-                let power = p.operating_power().get::<watt>();
-                println!(
-                    "             RDO: Requesting Battery PDO#{} @ {:.2}W",
-                    p.object_position(),
-                    power
-                );
-            }
-            PowerSource::Pps(p) => {
-                let v = p.output_voltage().get::<volt>();
-                let c = p.operating_current().get::<ampere>();
-                println!(
-                    "             RDO: Requesting PPS PDO#{} @ {:.2}V / {:.2}A",
-                    p.object_position(),
-                    v,
-                    c
-                );
-            }
-            PowerSource::Avs(p) => {
-                let v = p.output_voltage().get::<volt>();
-                let c = p.operating_current().get::<ampere>();
-                println!(
-                    "             RDO: Requesting AVS PDO#{} @ {:.2}V / {:.2}A",
-                    p.object_position(),
-                    v,
-                    c
-                );
-            }
-            PowerSource::EprRequest { rdo, pdo } => {
-                use usbpd::protocol_layer::message::data::request::{
-                    Avs as RdoAvs, FixedVariableSupply as RdoFixed, RawDataObject,
-                };
-                use usbpd::protocol_layer::message::data::source_capabilities::PowerDataObject;
-
-                let pos = RawDataObject(*rdo).object_position();
-
-                // Parse the RDO based on the PDO type
-                match pdo {
-                    PowerDataObject::FixedSupply(f) => {
-                        let rdo_parsed = RdoFixed(*rdo);
-                        let curr = rdo_parsed.operating_current().get::<ampere>();
-                        let max_curr = rdo_parsed.max_operating_current().get::<ampere>();
-                        let voltage = f.voltage().get::<volt>();
-                        println!(
-                            "             RDO: EPR Fixed PDO#{} ({:.1}V) @ {:.2}A (Max {:.2}A)",
-                            pos, voltage, curr, max_curr
-                        );
-                    }
-                    PowerDataObject::Augmented(a) => {
-                        use usbpd::protocol_layer::message::data::source_capabilities::Augmented;
-                        match a {
-                            Augmented::Spr(pps) => {
-                                let rdo_parsed = RdoAvs(*rdo);
-                                let v = rdo_parsed.output_voltage().get::<volt>();
-                                let c = rdo_parsed.operating_current().get::<ampere>();
-                                println!(
-                                    "             RDO: EPR PPS PDO#{} ({:.1}-{:.1}V) @ {:.2}V / {:.2}A",
-                                    pos,
-                                    pps.min_voltage().get::<volt>(),
-                                    pps.max_voltage().get::<volt>(),
-                                    v,
-                                    c
-                                );
-                            }
-                            Augmented::Epr(avs) => {
-                                let rdo_parsed = RdoAvs(*rdo);
-                                let v = rdo_parsed.output_voltage().get::<volt>();
-                                let c = rdo_parsed.operating_current().get::<ampere>();
-                                println!(
-                                    "             RDO: EPR AVS PDO#{} ({:.1}-{:.1}V @ {:.0}W) @ {:.2}V / {:.2}A",
-                                    pos,
-                                    avs.min_voltage().get::<volt>(),
-                                    avs.max_voltage().get::<volt>(),
-                                    avs.pd_power().get::<watt>(),
-                                    v,
-                                    c
-                                );
-                            }
-                            _ => {
-                                println!("             RDO: EPR Augmented PDO#{} (Raw=0x{:08X})", pos, rdo);
-                            }
-                        }
-                    }
-                    _ => {
-                        println!("             RDO: EPR PDO#{} (Raw=0x{:08X}, PDO={:?})", pos, rdo, pdo);
-                    }
-                }
-            }
-            PowerSource::Unknown(raw) => {
-                let pos = raw.object_position();
-
-                if let Some(caps) = &self.source_caps
-                    && let Some(pdo) = caps.pdos().get(pos as usize - 1)
-                {
-                    // Try to parse as FixedVariableSupply RDO and show nice format
-                    let rdo_parsed = data::request::FixedVariableSupply(raw.0);
-                    let curr = rdo_parsed.operating_current().get::<ampere>();
-                    println!(
-                        "             RDO: Requesting PDO#{} ({}) @ {:.1}A",
-                        pos,
-                        format_pdo(pdo),
-                        curr
-                    );
-                } else {
-                    println!("             RDO: Requesting PDO#{} (Raw=0x{:08X})", pos, raw.0);
-                }
-            }
-        }
-    }
 }
 
 #[tokio::main]
@@ -425,7 +46,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     tracing_subscriber::fmt::init();
 
-    // PD capture requires vendor interface (HID causes device crashes)
     let config = if args.no_reset && !args.reset {
         DeviceConfig::vendor().skip_reset()
     } else {
@@ -434,14 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut device = KM003C::new(config).await?;
     let state = device.state().expect("vendor interface provides state");
-
-    println!("{}\n", state);
-
-    // Note: EnablePdMonitor (0x10) and DisablePdMonitor (0x11) commands exist in the protocol
-    // and are used by the official app, but PD capture works without them.
-    // Their exact purpose is unclear. Sending EnablePdMonitor over HID crashes the device.
-    // Keeping them commented out for reference:
-    // device.enable_pd_monitor().await?;
+    println!("{state}\n");
 
     println!("USB PD Negotiation Capture");
     println!("NOW: Disconnect and reconnect your USB-C load!");
@@ -452,39 +65,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let start_time = Instant::now();
     let duration = Duration::from_secs(args.duration);
-    let mut decoder = PdDecoder::new(args.raw);
+    let mut decoder = PdSessionDecoder::new();
 
     loop {
         if start_time.elapsed() >= duration {
             break;
         }
 
-        match device.request_pd_data().await {
-            Ok(packet) => {
-                if let Some(stream) = KM003C::extract_pd_events(&packet) {
-                    for event in &stream.events {
-                        match &event.data {
-                            PdEventData::Connect(_) => {
-                                println!(
-                                    "[{:>8.3}s] ** CONNECT **",
-                                    event.timestamp.get::<km003c_millisecond>() / 1000.0
-                                );
-                                decoder.handle_connect();
-                            }
-                            PdEventData::Disconnect(_) => {
-                                println!(
-                                    "[{:>8.3}s] ** DISCONNECT **",
-                                    event.timestamp.get::<km003c_millisecond>() / 1000.0
-                                );
-                            }
-                            PdEventData::PdMessage { sop, wire_data } => {
-                                decoder.decode(event.timestamp.get::<km003c_millisecond>() as u32, *sop, wire_data);
-                            }
-                        }
-                    }
+        if let Ok(packet) = device.request_pd_data().await
+            && let Some(stream) = KM003C::extract_pd_events(&packet)
+        {
+            for event in &stream.events {
+                if args.raw
+                    && let PdEventData::PdMessage { wire_data, .. } = &event.data
+                {
+                    print_raw(event.timestamp.get::<millisecond>(), wire_data);
                 }
+
+                let decoded = decoder.decode_event(event);
+                print_decoded(&decoded, decoder.source_capabilities());
             }
-            Err(_e) => {}
         }
 
         tokio::select! {
@@ -496,11 +96,265 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // See note above about EnablePdMonitor/DisablePdMonitor - purpose unclear, works without them
-    // device.disable_pd_monitor().await?;
-
     device.send(Packet::Disconnect).await?;
     println!("\nCapture complete.");
-
     Ok(())
+}
+
+fn print_raw(timestamp_ms: f64, wire_data: &[u8]) {
+    print!("[{:>8.3}s] RAW[{}]: ", timestamp_ms / 1000.0, wire_data.len());
+    for (index, byte) in wire_data.iter().enumerate() {
+        if index > 0 && index % 16 == 0 {
+            print!("\n                     ");
+        }
+        print!("{byte:02X} ");
+    }
+    println!();
+}
+
+fn print_decoded(decoded: &DecodedPdEvent, source_caps: Option<&SourceCapabilities>) {
+    match decoded {
+        DecodedPdEvent::Connect { timestamp } => {
+            println!("[{:>8.3}s] ** CONNECT **", timestamp.get::<millisecond>() / 1000.0);
+        }
+        DecodedPdEvent::Disconnect { timestamp } => {
+            println!("[{:>8.3}s] ** DISCONNECT **", timestamp.get::<millisecond>() / 1000.0);
+        }
+        DecodedPdEvent::Message(message) => print_message(message, source_caps),
+        DecodedPdEvent::Chunk(status) => print_chunk_status(*status),
+        DecodedPdEvent::Error(failure) => print_failure(failure),
+    }
+}
+
+fn print_message(decoded: &DecodedPdMessage, source_caps: Option<&SourceCapabilities>) {
+    let message = &decoded.message;
+    println!(
+        "[{:>8.3}s] SOP{}: {:<20} (ID={}, ROLE={:?}/{:?})",
+        decoded.timestamp.get::<millisecond>() / 1000.0,
+        decoded.sop,
+        format!("{:?}", message.header.message_type()),
+        message.header.message_id(),
+        message.header.port_power_role(),
+        message.header.port_data_role(),
+    );
+
+    match &message.payload {
+        Some(Payload::Data(Data::SourceCapabilities(capabilities))) => {
+            print_capabilities(capabilities.pdos(), "SPR Source Capabilities");
+        }
+        Some(Payload::Data(Data::Request(request))) => print_request(request, source_caps),
+        Some(Payload::Data(Data::EprMode(mode))) => println!("             EPR Mode: {mode:?}"),
+        Some(Payload::Data(Data::Unknown)) => println!("             Unknown Data Message"),
+        Some(Payload::Data(data)) => println!("             Data: {data:?}"),
+        Some(Payload::Extended(Extended::EprSourceCapabilities(pdos))) => {
+            print_capabilities(pdos.as_slice(), "EPR Source Capabilities");
+        }
+        Some(Payload::Extended(Extended::ExtendedControl(control))) => println!(
+            "             Extended Control: {:?} (data=0x{:02X})",
+            control.message_type(),
+            control.data()
+        ),
+        Some(Payload::Extended(extended)) => println!("             Extended: {extended:?}"),
+        None => {}
+    }
+}
+
+fn print_chunk_status(status: PdChunkStatus) {
+    let timestamp = status.timestamp.get::<millisecond>() / 1000.0;
+    match status.state {
+        PdChunkState::Request { chunk_number } => println!(
+            "[{timestamp:>8.3}s] SOP{}: Chunk Request (chunk={chunk_number}, type={:?})",
+            status.sop, status.message_type
+        ),
+        PdChunkState::Pending {
+            received_chunk,
+            next_chunk,
+        } => println!(
+            "[{timestamp:>8.3}s] SOP{}: {:?} chunk {received_chunk} received, waiting for chunk {next_chunk}",
+            status.sop, status.message_type
+        ),
+        PdChunkState::Requested { chunk_number } => println!(
+            "[{timestamp:>8.3}s] SOP{}: {:?} chunk {chunk_number} requested",
+            status.sop, status.message_type
+        ),
+        PdChunkState::Unsupported {
+            chunk_number,
+            data_size,
+        } => println!(
+            "[{timestamp:>8.3}s] SOP{}: Chunked {:?} (chunk {chunk_number}, {data_size} bytes) - not assembled",
+            status.sop, status.message_type
+        ),
+    }
+}
+
+fn print_failure(failure: &PdDecodeFailure) {
+    println!(
+        "[{:>8.3}s] SOP{}: Failed to parse: {} (Hex: {:02X?})",
+        failure.timestamp.get::<millisecond>() / 1000.0,
+        failure.sop,
+        failure.error,
+        failure.wire_data
+    );
+}
+
+fn print_request(request: &data::request::PowerSource, source_caps: Option<&SourceCapabilities>) {
+    use data::request::PowerSource;
+
+    match request {
+        PowerSource::FixedVariableSupply(request) => {
+            let current = request.operating_current().get::<ampere>();
+            let max_current = request.max_operating_current().get::<ampere>();
+            let position = request.object_position();
+            if let Some(pdo) = source_caps.and_then(|caps| caps.pdos().get(position as usize - 1)) {
+                println!("             RDO: PDO#{position} ({}) @ {current:.1}A", format_pdo(pdo));
+            } else {
+                println!("             RDO: PDO#{position} @ {current:.1}A (Max {max_current:.1}A)");
+            }
+        }
+        PowerSource::Battery(request) => println!(
+            "             RDO: Requesting Battery PDO#{} @ {:.2}W",
+            request.object_position(),
+            request.operating_power().get::<watt>()
+        ),
+        PowerSource::Pps(request) => println!(
+            "             RDO: Requesting PPS PDO#{} @ {:.2}V / {:.2}A",
+            request.object_position(),
+            request.output_voltage().get::<volt>(),
+            request.operating_current().get::<ampere>()
+        ),
+        PowerSource::Avs(request) => println!(
+            "             RDO: Requesting AVS PDO#{} @ {:.2}V / {:.2}A",
+            request.object_position(),
+            request.output_voltage().get::<volt>(),
+            request.operating_current().get::<ampere>()
+        ),
+        PowerSource::EprRequest { rdo, pdo } => print_epr_request(*rdo, pdo),
+        PowerSource::Unknown(raw) => {
+            let position = raw.object_position();
+            if let Some(pdo) = source_caps.and_then(|caps| caps.pdos().get(position as usize - 1)) {
+                let request = data::request::FixedVariableSupply(raw.0);
+                println!(
+                    "             RDO: Requesting PDO#{position} ({}) @ {:.1}A",
+                    format_pdo(pdo),
+                    request.operating_current().get::<ampere>()
+                );
+            } else {
+                println!("             RDO: Requesting PDO#{position} (Raw=0x{:08X})", raw.0);
+            }
+        }
+    }
+}
+
+fn print_epr_request(rdo: u32, pdo: &PowerDataObject) {
+    use data::request::{Avs as RdoAvs, FixedVariableSupply as RdoFixed, RawDataObject};
+
+    let position = RawDataObject(rdo).object_position();
+    match pdo {
+        PowerDataObject::FixedSupply(fixed) => {
+            let request = RdoFixed(rdo);
+            println!(
+                "             RDO: EPR Fixed PDO#{position} ({:.1}V) @ {:.2}A (Max {:.2}A)",
+                fixed.voltage().get::<volt>(),
+                request.operating_current().get::<ampere>(),
+                request.max_operating_current().get::<ampere>()
+            );
+        }
+        PowerDataObject::Augmented(Augmented::Spr(pps)) => {
+            let request = RdoAvs(rdo);
+            println!(
+                "             RDO: EPR PPS PDO#{position} ({:.1}-{:.1}V) @ {:.2}V / {:.2}A",
+                pps.min_voltage().get::<volt>(),
+                pps.max_voltage().get::<volt>(),
+                request.output_voltage().get::<volt>(),
+                request.operating_current().get::<ampere>()
+            );
+        }
+        PowerDataObject::Augmented(Augmented::Epr(avs)) => {
+            let request = RdoAvs(rdo);
+            println!(
+                "             RDO: EPR AVS PDO#{position} ({:.1}-{:.1}V @ {:.0}W) @ {:.2}V / {:.2}A",
+                avs.min_voltage().get::<volt>(),
+                avs.max_voltage().get::<volt>(),
+                avs.pd_power().get::<watt>(),
+                request.output_voltage().get::<volt>(),
+                request.operating_current().get::<ampere>()
+            );
+        }
+        PowerDataObject::Augmented(_) => {
+            println!("             RDO: EPR Augmented PDO#{position} (Raw=0x{rdo:08X})");
+        }
+        _ => println!("             RDO: EPR PDO#{position} (Raw=0x{rdo:08X}, PDO={pdo:?})"),
+    }
+}
+
+fn format_pdo(pdo: &PowerDataObject) -> String {
+    match pdo {
+        PowerDataObject::FixedSupply(fixed) => {
+            let voltage = fixed.voltage().get::<volt>();
+            let current = fixed.max_current().get::<ampere>();
+            let mut flags = Vec::new();
+            if fixed.dual_role_power() {
+                flags.push("DRP");
+            }
+            if fixed.usb_communications_capable() {
+                flags.push("USB");
+            }
+            if fixed.dual_role_data() {
+                flags.push("DRD");
+            }
+            if fixed.unconstrained_power() {
+                flags.push("UP");
+            }
+            if fixed.epr_mode_capable() {
+                flags.push("EPR");
+            }
+            let flags = if flags.is_empty() {
+                String::new()
+            } else {
+                format!(" [{}]", flags.join(","))
+            };
+            format!("Fixed {voltage:.0}V @ {current:.1}A ({:.0}W){flags}", voltage * current)
+        }
+        PowerDataObject::Battery(battery) => format!(
+            "Battery {:.0}-{:.0}V @ {:.0}W",
+            battery.min_voltage().get::<volt>(),
+            battery.max_voltage().get::<volt>(),
+            battery.max_power().get::<watt>()
+        ),
+        PowerDataObject::VariableSupply(variable) => format!(
+            "Variable {:.0}-{:.0}V @ {:.1}A",
+            variable.min_voltage().get::<volt>(),
+            variable.max_voltage().get::<volt>(),
+            variable.max_current().get::<ampere>()
+        ),
+        PowerDataObject::Augmented(Augmented::Spr(pps)) => {
+            let min_voltage = pps.min_voltage().get::<volt>();
+            let max_voltage = pps.max_voltage().get::<volt>();
+            let current = pps.max_current().get::<ampere>();
+            let limited = if pps.pps_power_limited() { " (limited)" } else { "" };
+            format!(
+                "PPS {min_voltage:.1}-{max_voltage:.1}V @ {current:.1}A ({:.0}W){limited}",
+                max_voltage * current
+            )
+        }
+        PowerDataObject::Augmented(Augmented::Epr(avs)) => format!(
+            "EPR AVS {:.0}-{:.0}V @ {:.0}W",
+            avs.min_voltage().get::<volt>(),
+            avs.max_voltage().get::<volt>(),
+            avs.pd_power().get::<watt>()
+        ),
+        PowerDataObject::Augmented(Augmented::Unknown(raw)) => format!("Augmented(0x{raw:08X})"),
+        PowerDataObject::Unknown(raw) => format!("Unknown(0x{:08X})", raw.0),
+    }
+}
+
+fn print_capabilities(capabilities: &[PowerDataObject], title: &str) {
+    println!("             [{title}]");
+    for (index, pdo) in capabilities.iter().enumerate() {
+        if matches!(pdo, PowerDataObject::FixedSupply(fixed) if fixed.0 == 0) {
+            println!("             PDO[{}]: --- (separator) ---", index + 1);
+        } else {
+            println!("             PDO[{}]: {}", index + 1, format_pdo(pdo));
+        }
+    }
 }

--- a/km003c-egui/Cargo.toml
+++ b/km003c-egui/Cargo.toml
@@ -14,12 +14,9 @@ name = "km003c-egui"
 path = "src/main.rs"
 
 [dependencies]
-km003c-lib.workspace = true
+km003c-lib = { workspace = true, features = ["usbpd"] }
 eframe = "0.35.0"
 egui_plot = "0.36.0"
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-usbpd.workspace = true
-# Keep this aligned with usbpd's public quantity types.
-uom.workspace = true

--- a/km003c-egui/src/main.rs
+++ b/km003c-egui/src/main.rs
@@ -1,3 +1,4 @@
+mod pd_connection;
 mod pd_decoder;
 
 use eframe::egui;
@@ -9,9 +10,10 @@ use km003c_lib::uom::si::time::second;
 use km003c_lib::{
     AdcQueueSample, DeviceConfig, DeviceState, GraphSampleRate, KM003C,
     packet::{Attribute, AttributeSet},
-    pd::{PdEvent, PdStatus},
+    pd::{PdEvent, PdEventData, PdStatus},
     sequence_elapsed,
 };
+use pd_connection::PdConnectionTracker;
 use pd_decoder::{DecodedPdEntry, PdCategory, PdDecoder};
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -177,6 +179,8 @@ struct PowerMonitorApp {
     max_pd_entries: usize,
     /// Current PD status
     pd_status: Option<PdStatus>,
+    /// Debounced phone connection state
+    pd_connection: PdConnectionTracker,
     /// Auto-scroll PD log
     pd_auto_scroll: bool,
     /// PD panel visible
@@ -210,6 +214,7 @@ impl PowerMonitorApp {
             pd_log: VecDeque::new(),
             max_pd_entries: 1000,
             pd_status: None,
+            pd_connection: PdConnectionTracker::default(),
             pd_auto_scroll: true,
             pd_panel_visible: true,
             usb_reset: !cfg!(target_os = "macos"),
@@ -222,6 +227,7 @@ impl PowerMonitorApp {
                 UsbMessage::Connected(state) => {
                     self.status = format!("Connected: {}", state.model());
                     self.device_state = Some(state);
+                    self.pd_connection = PdConnectionTracker::default();
                 }
                 UsbMessage::ConnectionFailed(err) => {
                     self.status = format!("Connection failed: {}", err);
@@ -285,6 +291,16 @@ impl PowerMonitorApp {
                 }
                 UsbMessage::PdEvents(events) => {
                     for event in &events {
+                        match &event.data {
+                            PdEventData::Connect(()) => {
+                                self.pd_connection.observe_event(true, std::time::Instant::now());
+                            }
+                            PdEventData::Disconnect(()) => {
+                                self.pd_connection.observe_event(false, std::time::Instant::now());
+                            }
+                            PdEventData::PdMessage { .. } => {}
+                        }
+
                         let entries = self.pd_decoder.decode_event(event);
                         for entry in entries {
                             self.pd_log.push_back(entry);
@@ -295,6 +311,7 @@ impl PowerMonitorApp {
                     }
                 }
                 UsbMessage::PdStatusUpdate(status) => {
+                    self.pd_connection.observe_status(&status, std::time::Instant::now());
                     self.pd_status = Some(status);
                 }
                 UsbMessage::StreamingStopped => {
@@ -308,9 +325,13 @@ impl PowerMonitorApp {
                     self.status = "Disconnected".to_string();
                     self.streaming = false;
                     self.device_state = None;
+                    self.pd_status = None;
+                    self.pd_connection = PdConnectionTracker::default();
                 }
             }
         }
+
+        self.pd_connection.update(std::time::Instant::now());
     }
 
     fn clear_data(&mut self) {
@@ -449,7 +470,7 @@ impl eframe::App for PowerMonitorApp {
                     .show(ui, |ui| {
                         ui.label("CC1:");
                         let cc1_v = pd.cc1.get::<volt>();
-                        let cc1_color = if cc1_v > 0.2 {
+                        let cc1_color = if self.pd_connection.connected() == Some(true) && cc1_v > 0.2 {
                             egui::Color32::GREEN
                         } else {
                             egui::Color32::GRAY
@@ -459,7 +480,7 @@ impl eframe::App for PowerMonitorApp {
 
                         ui.label("CC2:");
                         let cc2_v = pd.cc2.get::<volt>();
-                        let cc2_color = if cc2_v > 0.2 {
+                        let cc2_color = if self.pd_connection.connected() == Some(true) && cc2_v > 0.2 {
                             egui::Color32::GREEN
                         } else {
                             egui::Color32::GRAY
@@ -467,16 +488,13 @@ impl eframe::App for PowerMonitorApp {
                         ui.colored_label(cc2_color, format!("{cc2_v:.3} V"));
                         ui.end_row();
 
-                        ui.label("Connection:");
-                        let connected = cc1_v > 0.2 || cc2_v > 0.2;
-                        ui.colored_label(
-                            if connected {
-                                egui::Color32::GREEN
-                            } else {
-                                egui::Color32::RED
-                            },
-                            if connected { "Connected" } else { "No device" },
-                        );
+                        ui.label("Type-C sink:");
+                        let (color, label) = match self.pd_connection.connected() {
+                            Some(true) => (egui::Color32::GREEN, "Attached"),
+                            Some(false) => (egui::Color32::RED, "Not attached"),
+                            None => (egui::Color32::YELLOW, "Detecting..."),
+                        };
+                        ui.colored_label(color, label);
                         ui.end_row();
                     });
             } else {
@@ -869,6 +887,7 @@ async fn run_streaming_session(
                 }
 
                 if let Some(stream) = packet.get_pd_events() {
+                    let _ = tx.send(UsbMessage::PdStatusUpdate(stream.preamble));
                     let _ = tx.send(UsbMessage::PdEvents(stream.events.clone()));
                 }
                 if let Some(status) = packet.get_pd_status() {

--- a/km003c-egui/src/pd_connection.rs
+++ b/km003c-egui/src/pd_connection.rs
@@ -1,0 +1,185 @@
+use std::time::{Duration, Instant};
+
+use km003c_lib::pd::PdStatus;
+use km003c_lib::uom::si::electric_potential::volt;
+
+// On the KM003C's downstream/source-facing CC pins, an attached sink's Rd
+// pulls the active line into the Type-C detection range. An open source CC
+// line instead sits near 3.2 V, while an unpowered line sits near 0 V.
+const CONNECT_MIN_V: f64 = 0.20;
+const CONNECT_MAX_V: f64 = 2.45;
+const DISCONNECT_LOW_V: f64 = 0.10;
+const DISCONNECT_HIGH_V: f64 = 2.75;
+const CONNECTION_DEBOUNCE: Duration = Duration::from_millis(100);
+
+#[derive(Debug, Clone, Copy)]
+struct PendingState {
+    connected: bool,
+    since: Instant,
+}
+
+/// Stable phone connection state derived from PD events or, until the first
+/// connection event arrives, debounced CC voltage measurements.
+#[derive(Debug, Default)]
+pub struct PdConnectionTracker {
+    connected: Option<bool>,
+    pending: Option<PendingState>,
+    received_connection_event: bool,
+}
+
+impl PdConnectionTracker {
+    pub fn connected(&self) -> Option<bool> {
+        self.connected
+    }
+
+    pub fn observe_status(&mut self, status: &PdStatus, now: Instant) {
+        self.observe_status_voltages(status.cc1.get::<volt>(), status.cc2.get::<volt>(), now);
+    }
+
+    fn observe_status_voltages(&mut self, cc1_v: f64, cc2_v: f64, now: Instant) {
+        if self.received_connection_event {
+            return;
+        }
+
+        let active_cc_v = cc1_v.max(cc2_v);
+        let candidate = if (CONNECT_MIN_V..=CONNECT_MAX_V).contains(&active_cc_v) {
+            Some(true)
+        } else if active_cc_v <= DISCONNECT_LOW_V || active_cc_v >= DISCONNECT_HIGH_V {
+            Some(false)
+        } else {
+            None
+        };
+
+        if let Some(candidate) = candidate {
+            self.observe_candidate(candidate, now);
+        } else {
+            self.pending = None;
+        }
+    }
+
+    pub fn observe_event(&mut self, connected: bool, now: Instant) {
+        self.received_connection_event = true;
+        self.observe_candidate(connected, now);
+    }
+
+    pub fn update(&mut self, now: Instant) {
+        let Some(pending) = self.pending else {
+            return;
+        };
+
+        if now.saturating_duration_since(pending.since) >= CONNECTION_DEBOUNCE {
+            self.connected = Some(pending.connected);
+            self.pending = None;
+        }
+    }
+
+    fn observe_candidate(&mut self, connected: bool, now: Instant) {
+        if self.connected == Some(connected) {
+            self.pending = None;
+            return;
+        }
+
+        if self.pending.is_none_or(|pending| pending.connected != connected) {
+            self.pending = Some(PendingState { connected, since: now });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn advance(start: Instant, millis: u64) -> Instant {
+        start + Duration::from_millis(millis)
+    }
+
+    fn settle_voltages(tracker: &mut PdConnectionTracker, cc1_v: f64, cc2_v: f64, start: Instant) {
+        tracker.observe_status_voltages(cc1_v, cc2_v, start);
+        tracker.update(advance(start, 100));
+    }
+
+    #[test]
+    fn ignores_a_short_cc_disconnect_spike() {
+        let start = Instant::now();
+        let mut tracker = PdConnectionTracker::default();
+        settle_voltages(&mut tracker, 1.65, 0.0, start);
+        assert_eq!(tracker.connected(), Some(true));
+
+        tracker.observe_status_voltages(3.21, 0.0, advance(start, 110));
+        tracker.observe_status_voltages(1.65, 0.0, advance(start, 150));
+        tracker.update(advance(start, 250));
+
+        assert_eq!(tracker.connected(), Some(true));
+    }
+
+    #[test]
+    fn accepts_a_sustained_cc_disconnect() {
+        let start = Instant::now();
+        let mut tracker = PdConnectionTracker::default();
+        settle_voltages(&mut tracker, 1.65, 0.0, start);
+        assert_eq!(tracker.connected(), Some(true));
+
+        tracker.observe_status_voltages(3.21, 0.0, advance(start, 110));
+        tracker.update(advance(start, 210));
+
+        assert_eq!(tracker.connected(), Some(false));
+    }
+
+    #[test]
+    fn connection_events_take_priority_over_cc_voltage() {
+        let start = Instant::now();
+        let mut tracker = PdConnectionTracker::default();
+        settle_voltages(&mut tracker, 1.65, 0.0, start);
+        assert_eq!(tracker.connected(), Some(true));
+
+        tracker.observe_event(false, advance(start, 110));
+        tracker.observe_status_voltages(1.65, 0.0, advance(start, 150));
+        tracker.update(advance(start, 210));
+
+        assert_eq!(tracker.connected(), Some(false));
+    }
+
+    #[test]
+    fn debounces_contradictory_connection_events() {
+        let start = Instant::now();
+        let mut tracker = PdConnectionTracker::default();
+        settle_voltages(&mut tracker, 1.65, 0.0, start);
+        assert_eq!(tracker.connected(), Some(true));
+
+        tracker.observe_event(false, advance(start, 110));
+        tracker.observe_event(true, advance(start, 150));
+        tracker.update(advance(start, 250));
+
+        assert_eq!(tracker.connected(), Some(true));
+    }
+
+    #[test]
+    fn recorded_open_source_cc_is_not_a_connected_sink() {
+        let start = Instant::now();
+        let mut tracker = PdConnectionTracker::default();
+
+        settle_voltages(&mut tracker, 3.237, 0.125, start);
+
+        assert_eq!(tracker.connected(), Some(false));
+    }
+
+    #[test]
+    fn recorded_rd_voltage_is_a_connected_sink() {
+        let start = Instant::now();
+        let mut tracker = PdConnectionTracker::default();
+
+        settle_voltages(&mut tracker, 1.654, 0.002, start);
+
+        assert_eq!(tracker.connected(), Some(true));
+    }
+
+    #[test]
+    fn unpowered_cc_lines_are_not_connected() {
+        let start = Instant::now();
+        let mut tracker = PdConnectionTracker::default();
+
+        settle_voltages(&mut tracker, 0.0, 0.0, start);
+
+        assert_eq!(tracker.connected(), Some(false));
+    }
+}

--- a/km003c-egui/src/pd_decoder.rs
+++ b/km003c-egui/src/pd_decoder.rs
@@ -1,29 +1,29 @@
-use km003c_lib::pd::{PdEvent, PdEventData};
-use usbpd::protocol_layer::message::data::source_capabilities::{Augmented, PowerDataObject, SourceCapabilities};
-use usbpd::protocol_layer::message::data::{self, Data};
-use usbpd::protocol_layer::message::extended::Extended;
-use usbpd::protocol_layer::message::extended::chunked::{ChunkResult, ChunkedMessageAssembler};
-use usbpd::protocol_layer::message::header::ExtendedMessageType;
-use usbpd::protocol_layer::message::{Message, ParseError, Payload};
+use km003c_lib::pd::PdEvent;
+use km003c_lib::uom::si::electric_current::ampere;
+use km003c_lib::uom::si::electric_potential::volt;
+use km003c_lib::uom::si::power::watt;
+use km003c_lib::uom::si::time::millisecond;
+use km003c_lib::usbpd::protocol_layer::message::Payload;
+use km003c_lib::usbpd::protocol_layer::message::data::source_capabilities::{
+    Augmented, PowerDataObject, SourceCapabilities,
+};
+use km003c_lib::usbpd::protocol_layer::message::data::{self, Data};
+use km003c_lib::usbpd::protocol_layer::message::extended::Extended;
+use km003c_lib::{DecodedPdEvent, DecodedPdMessage, PdChunkState, PdChunkStatus, PdDecodeFailure, PdSessionDecoder};
 
-use km003c_lib::uom::si::time::millisecond as km003c_millisecond;
-use uom::si::electric_current::ampere;
-use uom::si::electric_potential::volt;
-use uom::si::power::watt;
-
-/// Category of a decoded PD entry, used for color-coding in the UI
+/// Category of a decoded PD entry, used for color-coding in the UI.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PdCategory {
     Connect,
     Disconnect,
     SourceCaps,
     Request,
-    Control,  // Accept, Reject, GoodCRC, PS_RDY, etc.
-    Extended, // EPR caps, extended control
-    Error,    // Parse failures
+    Control,
+    Extended,
+    Error,
 }
 
-/// A single decoded PD log entry for display
+/// A single decoded PD log entry for display.
 #[derive(Debug, Clone)]
 pub struct DecodedPdEntry {
     pub category: PdCategory,
@@ -31,466 +31,311 @@ pub struct DecodedPdEntry {
     pub details: Vec<String>,
 }
 
-/// PD protocol decoder that maintains state across events
+/// UI formatter backed by the shared stateful decoder in `km003c-lib`.
 pub struct PdDecoder {
-    source_caps: Option<SourceCapabilities>,
-    epr_assembler: ChunkedMessageAssembler,
+    session: PdSessionDecoder,
 }
 
 impl PdDecoder {
     pub fn new() -> Self {
         Self {
-            source_caps: None,
-            epr_assembler: ChunkedMessageAssembler::new(),
+            session: PdSessionDecoder::new(),
         }
     }
 
-    /// Reset state on new connection
-    pub fn handle_connect(&mut self) {
-        self.source_caps = None;
-        self.epr_assembler.reset();
-    }
-
-    /// Decode a PdEvent into one or more DecodedPdEntry structs
     pub fn decode_event(&mut self, event: &PdEvent) -> Vec<DecodedPdEntry> {
-        match &event.data {
-            PdEventData::Connect(()) => {
-                self.handle_connect();
-                vec![DecodedPdEntry {
-                    category: PdCategory::Connect,
-                    summary: format!(
-                        "[{:.3}s] ** CONNECT **",
-                        event.timestamp.get::<km003c_millisecond>() / 1000.0
-                    ),
-                    details: vec![],
-                }]
-            }
-            PdEventData::Disconnect(()) => {
-                vec![DecodedPdEntry {
-                    category: PdCategory::Disconnect,
-                    summary: format!(
-                        "[{:.3}s] ** DISCONNECT **",
-                        event.timestamp.get::<km003c_millisecond>() / 1000.0
-                    ),
-                    details: vec![],
-                }]
-            }
-            PdEventData::PdMessage { sop, wire_data } => {
-                self.decode_message(event.timestamp.get::<km003c_millisecond>() as u32, *sop, wire_data)
-            }
-        }
-    }
-
-    fn decode_message(&mut self, timestamp_ms: u32, sop: u8, wire_data: &[u8]) -> Vec<DecodedPdEntry> {
-        if wire_data.is_empty() {
-            return vec![];
-        }
-
-        let ts = timestamp_ms as f64 / 1000.0;
-
-        match Message::from_bytes(wire_data) {
-            Ok(msg) => {
-                let msg_type = msg.header.message_type();
-                let msg_id = msg.header.message_id();
-                let role = format!("{:?}/{:?}", msg.header.port_power_role(), msg.header.port_data_role());
-
-                let type_str = format!("{:?}", msg_type);
-                let summary = format!("[{:.3}s] SOP{}: {} (ID={}, ROLE={})", ts, sop, type_str, msg_id, role);
-
-                match &msg.payload {
-                    Some(Payload::Data(data)) => match data {
-                        Data::SourceCapabilities(caps) => {
-                            self.source_caps = Some(caps.clone());
-                            let details = format_capabilities(caps.pdos(), "SPR Source Capabilities");
-                            vec![DecodedPdEntry {
-                                category: PdCategory::SourceCaps,
-                                summary,
-                                details,
-                            }]
-                        }
-                        Data::Request(req) => {
-                            let details = self.format_request(req);
-                            vec![DecodedPdEntry {
-                                category: PdCategory::Request,
-                                summary,
-                                details,
-                            }]
-                        }
-                        Data::EprMode(mode) => {
-                            vec![DecodedPdEntry {
-                                category: PdCategory::Extended,
-                                summary,
-                                details: vec![format!("EPR Mode: {:?}", mode)],
-                            }]
-                        }
-                        Data::Unknown => {
-                            vec![DecodedPdEntry {
-                                category: PdCategory::Control,
-                                summary,
-                                details: vec!["Unknown Data Message".to_string()],
-                            }]
-                        }
-                        _ => {
-                            vec![DecodedPdEntry {
-                                category: PdCategory::Control,
-                                summary,
-                                details: vec![format!("Data: {:?}", data)],
-                            }]
-                        }
-                    },
-                    Some(Payload::Extended(ext)) => match ext {
-                        Extended::EprSourceCapabilities(pdos) => {
-                            let details = format_capabilities(pdos.as_slice(), "EPR Source Capabilities");
-                            vec![DecodedPdEntry {
-                                category: PdCategory::Extended,
-                                summary,
-                                details,
-                            }]
-                        }
-                        Extended::ExtendedControl(ctrl) => {
-                            vec![DecodedPdEntry {
-                                category: PdCategory::Extended,
-                                summary,
-                                details: vec![format!(
-                                    "Extended Control: {:?} (data=0x{:02X})",
-                                    ctrl.message_type(),
-                                    ctrl.data()
-                                )],
-                            }]
-                        }
-                        _ => {
-                            vec![DecodedPdEntry {
-                                category: PdCategory::Extended,
-                                summary,
-                                details: vec![format!("Extended: {:?}", ext)],
-                            }]
-                        }
-                    },
-                    None => {
-                        // Control message (GoodCRC, Accept, etc.)
-                        vec![DecodedPdEntry {
-                            category: PdCategory::Control,
-                            summary,
-                            details: vec![],
-                        }]
-                    }
-                }
-            }
-            Err(ParseError::ChunkedExtendedMessage {
-                chunk_number,
-                data_size: _,
-                request_chunk,
-                message_type,
-            }) => self.handle_chunked(ts, sop, chunk_number, request_chunk, message_type, wire_data),
-            Err(e) => {
-                vec![DecodedPdEntry {
-                    category: PdCategory::Error,
-                    summary: format!("[{:.3}s] SOP{}: Parse error: {:?}", ts, sop, e),
-                    details: vec![format!("Hex: {:02X?}", wire_data)],
-                }]
-            }
-        }
-    }
-
-    fn handle_chunked(
-        &mut self,
-        ts: f64,
-        sop: u8,
-        chunk_number: u8,
-        request_chunk: bool,
-        message_type: ExtendedMessageType,
-        wire_data: &[u8],
-    ) -> Vec<DecodedPdEntry> {
-        if request_chunk {
-            return vec![DecodedPdEntry {
-                category: PdCategory::Extended,
-                summary: format!(
-                    "[{:.3}s] SOP{}: Chunk Request (chunk={}, type={:?})",
-                    ts, sop, chunk_number, message_type
-                ),
+        let decoded = self.session.decode_event(event);
+        vec![match decoded {
+            DecodedPdEvent::Connect { timestamp } => DecodedPdEntry {
+                category: PdCategory::Connect,
+                summary: format!("[{:.3}s] ** CONNECT **", timestamp.get::<millisecond>() / 1000.0),
                 details: vec![],
-            }];
-        }
-
-        if message_type != ExtendedMessageType::EprSourceCapabilities {
-            return vec![DecodedPdEntry {
-                category: PdCategory::Extended,
-                summary: format!(
-                    "[{:.3}s] SOP{}: Chunked {:?} (chunk {}) - not assembled",
-                    ts, sop, message_type, chunk_number
-                ),
+            },
+            DecodedPdEvent::Disconnect { timestamp } => DecodedPdEntry {
+                category: PdCategory::Disconnect,
+                summary: format!("[{:.3}s] ** DISCONNECT **", timestamp.get::<millisecond>() / 1000.0),
                 details: vec![],
-            }];
-        }
-
-        match Message::parse_extended_chunk(wire_data) {
-            Ok((header, ext_header, chunk_data)) => {
-                match self.epr_assembler.process_chunk(header, ext_header, chunk_data) {
-                    Ok(ChunkResult::Complete(assembled_data)) => {
-                        let ext = Message::parse_extended_payload(
-                            ExtendedMessageType::EprSourceCapabilities,
-                            &assembled_data,
-                        );
-
-                        if let Extended::EprSourceCapabilities(pdos) = ext {
-                            let msg_id = header.message_id();
-                            let role = format!("{:?}/{:?}", header.port_power_role(), header.port_data_role());
-                            let title = format!("EPR Source Capabilities - {} chunks assembled", chunk_number + 1);
-                            let details = format_capabilities(pdos.as_slice(), &title);
-                            vec![DecodedPdEntry {
-                                category: PdCategory::SourceCaps,
-                                summary: format!(
-                                    "[{:.3}s] SOP{}: Extended(EprSourceCapabilities) (ID={}, ROLE={})",
-                                    ts, sop, msg_id, role
-                                ),
-                                details,
-                            }]
-                        } else {
-                            vec![]
-                        }
-                    }
-                    Ok(ChunkResult::NeedMoreChunks(next)) => {
-                        vec![DecodedPdEntry {
-                            category: PdCategory::Extended,
-                            summary: format!(
-                                "[{:.3}s] SOP{}: EPR Source Caps chunk {} received, waiting for chunk {}...",
-                                ts, sop, chunk_number, next
-                            ),
-                            details: vec![],
-                        }]
-                    }
-                    Ok(ChunkResult::ChunkRequested(num)) => {
-                        vec![DecodedPdEntry {
-                            category: PdCategory::Extended,
-                            summary: format!("[{:.3}s] SOP{}: Chunk {} requested", ts, sop, num),
-                            details: vec![],
-                        }]
-                    }
-                    Err(e) => {
-                        self.epr_assembler.reset();
-                        vec![DecodedPdEntry {
-                            category: PdCategory::Error,
-                            summary: format!("[{:.3}s] SOP{}: Chunk assembly error: {:?}", ts, sop, e),
-                            details: vec![],
-                        }]
-                    }
-                }
-            }
-            Err(e) => {
-                vec![DecodedPdEntry {
-                    category: PdCategory::Error,
-                    summary: format!("[{:.3}s] SOP{}: Failed to parse chunk: {:?}", ts, sop, e),
-                    details: vec![],
-                }]
-            }
-        }
+            },
+            DecodedPdEvent::Message(message) => self.format_message(&message),
+            DecodedPdEvent::Chunk(status) => format_chunk_status(status),
+            DecodedPdEvent::Error(failure) => format_failure(failure),
+        }]
     }
 
-    fn format_request(&self, req: &data::request::PowerSource) -> Vec<String> {
-        use data::request::PowerSource;
+    fn format_message(&self, decoded: &DecodedPdMessage) -> DecodedPdEntry {
+        let message = &decoded.message;
+        let message_type = message.header.message_type();
+        let summary = format!(
+            "[{:.3}s] SOP{}: {:?} (ID={}, ROLE={:?}/{:?})",
+            decoded.timestamp.get::<millisecond>() / 1000.0,
+            decoded.sop,
+            message_type,
+            message.header.message_id(),
+            message.header.port_power_role(),
+            message.header.port_data_role(),
+        );
 
-        match req {
-            PowerSource::FixedVariableSupply(p) => {
-                let curr = p.operating_current().get::<ampere>();
-                let max_curr = p.max_operating_current().get::<ampere>();
-                let pos = p.object_position();
+        match &message.payload {
+            Some(Payload::Data(Data::SourceCapabilities(capabilities))) => DecodedPdEntry {
+                category: PdCategory::SourceCaps,
+                summary,
+                details: format_capabilities(capabilities.pdos(), "SPR Source Capabilities"),
+            },
+            Some(Payload::Data(Data::Request(request))) => DecodedPdEntry {
+                category: PdCategory::Request,
+                summary,
+                details: format_request(request, self.session.source_capabilities()),
+            },
+            Some(Payload::Data(Data::EprMode(mode))) => DecodedPdEntry {
+                category: PdCategory::Extended,
+                summary,
+                details: vec![format!("EPR Mode: {mode:?}")],
+            },
+            Some(Payload::Data(Data::Unknown)) => DecodedPdEntry {
+                category: PdCategory::Control,
+                summary,
+                details: vec!["Unknown Data Message".to_string()],
+            },
+            Some(Payload::Data(data)) => DecodedPdEntry {
+                category: PdCategory::Control,
+                summary,
+                details: vec![format!("Data: {data:?}")],
+            },
+            Some(Payload::Extended(Extended::EprSourceCapabilities(pdos))) => DecodedPdEntry {
+                category: PdCategory::Extended,
+                summary,
+                details: format_capabilities(pdos.as_slice(), "EPR Source Capabilities"),
+            },
+            Some(Payload::Extended(Extended::ExtendedControl(control))) => DecodedPdEntry {
+                category: PdCategory::Extended,
+                summary,
+                details: vec![format!(
+                    "Extended Control: {:?} (data=0x{:02X})",
+                    control.message_type(),
+                    control.data()
+                )],
+            },
+            Some(Payload::Extended(extended)) => DecodedPdEntry {
+                category: PdCategory::Extended,
+                summary,
+                details: vec![format!("Extended: {extended:?}")],
+            },
+            None => DecodedPdEntry {
+                category: PdCategory::Control,
+                summary,
+                details: vec![],
+            },
+        }
+    }
+}
 
-                let pdo_info = self
-                    .source_caps
-                    .as_ref()
-                    .and_then(|caps| caps.pdos().get(pos as usize - 1))
-                    .map(format_pdo);
+fn format_chunk_status(status: PdChunkStatus) -> DecodedPdEntry {
+    let timestamp = status.timestamp.get::<millisecond>() / 1000.0;
+    let summary = match status.state {
+        PdChunkState::Request { chunk_number } => format!(
+            "[{timestamp:.3}s] SOP{}: Chunk Request (chunk={chunk_number}, type={:?})",
+            status.sop, status.message_type
+        ),
+        PdChunkState::Pending {
+            received_chunk,
+            next_chunk,
+        } => format!(
+            "[{timestamp:.3}s] SOP{}: {:?} chunk {received_chunk} received, waiting for chunk {next_chunk}",
+            status.sop, status.message_type
+        ),
+        PdChunkState::Requested { chunk_number } => format!(
+            "[{timestamp:.3}s] SOP{}: {:?} chunk {chunk_number} requested",
+            status.sop, status.message_type
+        ),
+        PdChunkState::Unsupported {
+            chunk_number,
+            data_size,
+        } => format!(
+            "[{timestamp:.3}s] SOP{}: Chunked {:?} (chunk {chunk_number}, {data_size} bytes) - not assembled",
+            status.sop, status.message_type
+        ),
+    };
 
-                if let Some(info) = pdo_info {
-                    vec![format!("RDO: PDO#{} ({}) @ {:.1}A", pos, info, curr)]
-                } else {
-                    vec![format!("RDO: PDO#{} @ {:.1}A (Max {:.1}A)", pos, curr, max_curr)]
-                }
+    DecodedPdEntry {
+        category: PdCategory::Extended,
+        summary,
+        details: vec![],
+    }
+}
+
+fn format_failure(failure: PdDecodeFailure) -> DecodedPdEntry {
+    DecodedPdEntry {
+        category: PdCategory::Error,
+        summary: format!(
+            "[{:.3}s] SOP{}: Parse error: {}",
+            failure.timestamp.get::<millisecond>() / 1000.0,
+            failure.sop,
+            failure.error
+        ),
+        details: vec![format!("Hex: {:02X?}", failure.wire_data)],
+    }
+}
+
+fn format_request(request: &data::request::PowerSource, source_caps: Option<&SourceCapabilities>) -> Vec<String> {
+    use data::request::PowerSource;
+
+    match request {
+        PowerSource::FixedVariableSupply(request) => {
+            let current = request.operating_current().get::<ampere>();
+            let max_current = request.max_operating_current().get::<ampere>();
+            let position = request.object_position();
+            let pdo = source_caps
+                .and_then(|capabilities| capabilities.pdos().get(position as usize - 1))
+                .map(format_pdo);
+
+            if let Some(pdo) = pdo {
+                vec![format!("RDO: PDO#{position} ({pdo}) @ {current:.1}A")]
+            } else {
+                vec![format!("RDO: PDO#{position} @ {current:.1}A (Max {max_current:.1}A)")]
             }
-            PowerSource::Battery(p) => {
-                let power = p.operating_power().get::<watt>();
-                vec![format!(
-                    "RDO: Requesting Battery PDO#{} @ {:.2}W",
-                    p.object_position(),
-                    power
-                )]
-            }
-            PowerSource::Pps(p) => {
-                let v = p.output_voltage().get::<volt>();
-                let c = p.operating_current().get::<ampere>();
-                vec![format!(
-                    "RDO: Requesting PPS PDO#{} @ {:.2}V / {:.2}A",
-                    p.object_position(),
-                    v,
-                    c
-                )]
-            }
-            PowerSource::Avs(p) => {
-                let v = p.output_voltage().get::<volt>();
-                let c = p.operating_current().get::<ampere>();
-                vec![format!(
-                    "RDO: Requesting AVS PDO#{} @ {:.2}V / {:.2}A",
-                    p.object_position(),
-                    v,
-                    c
-                )]
-            }
-            PowerSource::EprRequest { rdo, pdo } => {
-                use usbpd::protocol_layer::message::data::request::{
-                    Avs as RdoAvs, FixedVariableSupply as RdoFixed, RawDataObject,
-                };
-                use usbpd::protocol_layer::message::data::source_capabilities::PowerDataObject;
+        }
+        PowerSource::Battery(request) => vec![format!(
+            "RDO: Requesting Battery PDO#{} @ {:.2}W",
+            request.object_position(),
+            request.operating_power().get::<watt>()
+        )],
+        PowerSource::Pps(request) => vec![format!(
+            "RDO: Requesting PPS PDO#{} @ {:.2}V / {:.2}A",
+            request.object_position(),
+            request.output_voltage().get::<volt>(),
+            request.operating_current().get::<ampere>()
+        )],
+        PowerSource::Avs(request) => vec![format!(
+            "RDO: Requesting AVS PDO#{} @ {:.2}V / {:.2}A",
+            request.object_position(),
+            request.output_voltage().get::<volt>(),
+            request.operating_current().get::<ampere>()
+        )],
+        PowerSource::EprRequest { rdo, pdo } => {
+            use data::request::{Avs as RdoAvs, FixedVariableSupply as RdoFixed, RawDataObject};
 
-                let pos = RawDataObject(*rdo).object_position();
-
-                match pdo {
-                    PowerDataObject::FixedSupply(f) => {
-                        let rdo_parsed = RdoFixed(*rdo);
-                        let curr = rdo_parsed.operating_current().get::<ampere>();
-                        let max_curr = rdo_parsed.max_operating_current().get::<ampere>();
-                        let voltage = f.voltage().get::<volt>();
-                        vec![format!(
-                            "RDO: EPR Fixed PDO#{} ({:.1}V) @ {:.2}A (Max {:.2}A)",
-                            pos, voltage, curr, max_curr
-                        )]
-                    }
-                    PowerDataObject::Augmented(a) => {
-                        use usbpd::protocol_layer::message::data::source_capabilities::Augmented;
-                        match a {
-                            Augmented::Spr(pps) => {
-                                let rdo_parsed = RdoAvs(*rdo);
-                                let v = rdo_parsed.output_voltage().get::<volt>();
-                                let c = rdo_parsed.operating_current().get::<ampere>();
-                                vec![format!(
-                                    "RDO: EPR PPS PDO#{} ({:.1}-{:.1}V) @ {:.2}V / {:.2}A",
-                                    pos,
-                                    pps.min_voltage().get::<volt>(),
-                                    pps.max_voltage().get::<volt>(),
-                                    v,
-                                    c
-                                )]
-                            }
-                            Augmented::Epr(avs) => {
-                                let rdo_parsed = RdoAvs(*rdo);
-                                let v = rdo_parsed.output_voltage().get::<volt>();
-                                let c = rdo_parsed.operating_current().get::<ampere>();
-                                vec![format!(
-                                    "RDO: EPR AVS PDO#{} ({:.1}-{:.1}V @ {:.0}W) @ {:.2}V / {:.2}A",
-                                    pos,
-                                    avs.min_voltage().get::<volt>(),
-                                    avs.max_voltage().get::<volt>(),
-                                    avs.pd_power().get::<watt>(),
-                                    v,
-                                    c
-                                )]
-                            }
-                            _ => {
-                                vec![format!("RDO: EPR Augmented PDO#{} (Raw=0x{:08X})", pos, rdo)]
-                            }
-                        }
-                    }
-                    _ => {
-                        vec![format!("RDO: EPR PDO#{} (Raw=0x{:08X}, PDO={:?})", pos, rdo, pdo)]
-                    }
-                }
-            }
-            PowerSource::Unknown(raw) => {
-                let pos = raw.object_position();
-
-                if let Some(caps) = &self.source_caps
-                    && let Some(pdo) = caps.pdos().get(pos as usize - 1)
-                {
-                    let rdo_parsed = data::request::FixedVariableSupply(raw.0);
-                    let curr = rdo_parsed.operating_current().get::<ampere>();
+            let position = RawDataObject(*rdo).object_position();
+            match pdo {
+                PowerDataObject::FixedSupply(fixed) => {
+                    let request = RdoFixed(*rdo);
                     vec![format!(
-                        "RDO: Requesting PDO#{} ({}) @ {:.1}A",
-                        pos,
-                        format_pdo(pdo),
-                        curr
+                        "RDO: EPR Fixed PDO#{position} ({:.1}V) @ {:.2}A (Max {:.2}A)",
+                        fixed.voltage().get::<volt>(),
+                        request.operating_current().get::<ampere>(),
+                        request.max_operating_current().get::<ampere>()
                     )]
-                } else {
-                    vec![format!("RDO: Requesting PDO#{} (Raw=0x{:08X})", pos, raw.0)]
                 }
+                PowerDataObject::Augmented(Augmented::Spr(pps)) => {
+                    let request = RdoAvs(*rdo);
+                    vec![format!(
+                        "RDO: EPR PPS PDO#{position} ({:.1}-{:.1}V) @ {:.2}V / {:.2}A",
+                        pps.min_voltage().get::<volt>(),
+                        pps.max_voltage().get::<volt>(),
+                        request.output_voltage().get::<volt>(),
+                        request.operating_current().get::<ampere>()
+                    )]
+                }
+                PowerDataObject::Augmented(Augmented::Epr(avs)) => {
+                    let request = RdoAvs(*rdo);
+                    vec![format!(
+                        "RDO: EPR AVS PDO#{position} ({:.1}-{:.1}V @ {:.0}W) @ {:.2}V / {:.2}A",
+                        avs.min_voltage().get::<volt>(),
+                        avs.max_voltage().get::<volt>(),
+                        avs.pd_power().get::<watt>(),
+                        request.output_voltage().get::<volt>(),
+                        request.operating_current().get::<ampere>()
+                    )]
+                }
+                PowerDataObject::Augmented(_) => {
+                    vec![format!("RDO: EPR Augmented PDO#{position} (Raw=0x{rdo:08X})")]
+                }
+                _ => vec![format!("RDO: EPR PDO#{position} (Raw=0x{rdo:08X}, PDO={pdo:?})")],
+            }
+        }
+        PowerSource::Unknown(raw) => {
+            let position = raw.object_position();
+            if let Some(pdo) = source_caps.and_then(|capabilities| capabilities.pdos().get(position as usize - 1)) {
+                let request = data::request::FixedVariableSupply(raw.0);
+                vec![format!(
+                    "RDO: Requesting PDO#{position} ({}) @ {:.1}A",
+                    format_pdo(pdo),
+                    request.operating_current().get::<ampere>()
+                )]
+            } else {
+                vec![format!("RDO: Requesting PDO#{position} (Raw=0x{:08X})", raw.0)]
             }
         }
     }
 }
 
-/// Format a single PDO for display
 fn format_pdo(pdo: &PowerDataObject) -> String {
     match pdo {
-        PowerDataObject::FixedSupply(f) => {
-            let v = f.voltage().get::<volt>();
-            let i = f.max_current().get::<ampere>();
-            let p = v * i;
+        PowerDataObject::FixedSupply(fixed) => {
+            let voltage = fixed.voltage().get::<volt>();
+            let current = fixed.max_current().get::<ampere>();
             let mut flags = Vec::new();
-            if f.dual_role_power() {
+            if fixed.dual_role_power() {
                 flags.push("DRP");
             }
-            if f.usb_communications_capable() {
+            if fixed.usb_communications_capable() {
                 flags.push("USB");
             }
-            if f.dual_role_data() {
+            if fixed.dual_role_data() {
                 flags.push("DRD");
             }
-            if f.unconstrained_power() {
+            if fixed.unconstrained_power() {
                 flags.push("UP");
             }
-            if f.epr_mode_capable() {
+            if fixed.epr_mode_capable() {
                 flags.push("EPR");
             }
-            let flags_str = if flags.is_empty() {
+            let flags = if flags.is_empty() {
                 String::new()
             } else {
                 format!(" [{}]", flags.join(","))
             };
-            format!("Fixed {:.0}V @ {:.1}A ({:.0}W){}", v, i, p, flags_str)
+            format!("Fixed {voltage:.0}V @ {current:.1}A ({:.0}W){flags}", voltage * current)
         }
-        PowerDataObject::Battery(b) => {
-            let min_v = b.min_voltage().get::<volt>();
-            let max_v = b.max_voltage().get::<volt>();
-            let p = b.max_power().get::<watt>();
-            format!("Battery {:.0}-{:.0}V @ {:.0}W", min_v, max_v, p)
+        PowerDataObject::Battery(battery) => format!(
+            "Battery {:.0}-{:.0}V @ {:.0}W",
+            battery.min_voltage().get::<volt>(),
+            battery.max_voltage().get::<volt>(),
+            battery.max_power().get::<watt>()
+        ),
+        PowerDataObject::VariableSupply(variable) => format!(
+            "Variable {:.0}-{:.0}V @ {:.1}A",
+            variable.min_voltage().get::<volt>(),
+            variable.max_voltage().get::<volt>(),
+            variable.max_current().get::<ampere>()
+        ),
+        PowerDataObject::Augmented(Augmented::Spr(pps)) => {
+            let min_voltage = pps.min_voltage().get::<volt>();
+            let max_voltage = pps.max_voltage().get::<volt>();
+            let current = pps.max_current().get::<ampere>();
+            let limited = if pps.pps_power_limited() { " (limited)" } else { "" };
+            format!(
+                "PPS {min_voltage:.1}-{max_voltage:.1}V @ {current:.1}A ({:.0}W){limited}",
+                max_voltage * current
+            )
         }
-        PowerDataObject::VariableSupply(v) => {
-            let min_v = v.min_voltage().get::<volt>();
-            let max_v = v.max_voltage().get::<volt>();
-            let i = v.max_current().get::<ampere>();
-            format!("Variable {:.0}-{:.0}V @ {:.1}A", min_v, max_v, i)
-        }
-        PowerDataObject::Augmented(aug) => match aug {
-            Augmented::Spr(pps) => {
-                let min_v = pps.min_voltage().get::<volt>();
-                let max_v = pps.max_voltage().get::<volt>();
-                let i = pps.max_current().get::<ampere>();
-                let p = max_v * i;
-                let limited = if pps.pps_power_limited() { " (limited)" } else { "" };
-                format!("PPS {:.1}-{:.1}V @ {:.1}A ({:.0}W){}", min_v, max_v, i, p, limited)
-            }
-            Augmented::Epr(avs) => {
-                let min_v = avs.min_voltage().get::<volt>();
-                let max_v = avs.max_voltage().get::<volt>();
-                let p = avs.pd_power().get::<watt>();
-                format!("EPR AVS {:.0}-{:.0}V @ {:.0}W", min_v, max_v, p)
-            }
-            Augmented::Unknown(raw) => {
-                format!("Augmented(0x{:08X})", raw)
-            }
-        },
-        PowerDataObject::Unknown(u) => {
-            format!("Unknown(0x{:08X})", u.0)
-        }
+        PowerDataObject::Augmented(Augmented::Epr(avs)) => format!(
+            "EPR AVS {:.0}-{:.0}V @ {:.0}W",
+            avs.min_voltage().get::<volt>(),
+            avs.max_voltage().get::<volt>(),
+            avs.pd_power().get::<watt>()
+        ),
+        PowerDataObject::Augmented(Augmented::Unknown(raw)) => format!("Augmented(0x{raw:08X})"),
+        PowerDataObject::Unknown(raw) => format!("Unknown(0x{:08X})", raw.0),
     }
 }
 
-/// Format source capabilities as a list of detail strings
-fn format_capabilities(caps: &[PowerDataObject], title: &str) -> Vec<String> {
-    let mut lines = vec![format!("[{}]", title)];
-    for (i, pdo) in caps.iter().enumerate() {
-        if matches!(pdo, PowerDataObject::FixedSupply(f) if f.0 == 0) {
-            lines.push(format!("PDO[{}]: --- (separator) ---", i + 1));
+fn format_capabilities(capabilities: &[PowerDataObject], title: &str) -> Vec<String> {
+    let mut lines = vec![format!("[{title}]")];
+    for (index, pdo) in capabilities.iter().enumerate() {
+        if matches!(pdo, PowerDataObject::FixedSupply(fixed) if fixed.0 == 0) {
+            lines.push(format!("PDO[{}]: --- (separator) ---", index + 1));
         } else {
-            lines.push(format!("PDO[{}]: {}", i + 1, format_pdo(pdo)));
+            lines.push(format!("PDO[{}]: {}", index + 1, format_pdo(pdo)));
         }
     }
     lines

--- a/km003c-lib/Cargo.toml
+++ b/km003c-lib/Cargo.toml
@@ -34,8 +34,10 @@ aes = "0.9.1"
 crc32fast = "1.5.0"
 rand = "0.10.2"
 uom.workspace = true
+usbpd = { workspace = true, optional = true }
 
 [features]
 default = []
 python = ["dep:pyo3"]
 serde = ["dep:serde", "uom/serde"]
+usbpd = ["dep:usbpd"]

--- a/km003c-lib/README.md
+++ b/km003c-lib/README.md
@@ -8,6 +8,10 @@ streaming at 2/10/50/1000 SPS, USB Power Delivery event capture, device
 information, and recorded-packet parsing. Physical measurements use
 [`uom`](https://docs.rs/uom) quantities throughout the Rust API.
 
+Enable the optional `usbpd` feature to turn captured PD wire frames into typed
+USB PD messages. `PdSessionDecoder` retains Source Capabilities state for
+subsequent Request messages and reassembles chunked EPR Source Capabilities.
+
 ```rust,no_run
 use km003c_lib::uom::si::electric_potential::volt;
 use km003c_lib::{DeviceConfig, KM003C};

--- a/km003c-lib/src/lib.rs
+++ b/km003c-lib/src/lib.rs
@@ -7,6 +7,8 @@ pub mod error;
 pub mod message;
 pub mod packet;
 pub mod pd;
+#[cfg(feature = "usbpd")]
+pub mod pd_decode;
 
 #[cfg(feature = "python")]
 pub mod python;
@@ -21,4 +23,10 @@ pub use device::{ConnectionMode, DeviceConfig, DeviceState, KM003C, TransferType
 pub use message::{Packet, PayloadData};
 pub use packet::{Attribute, AttributeSet, LogicalPacket, RawPacket};
 pub use pd::{PdEvent, PdEventData, PdEventStream, PdStatus};
+#[cfg(feature = "usbpd")]
+pub use pd_decode::{
+    DecodedPdEvent, DecodedPdMessage, PdChunkState, PdChunkStatus, PdDecodeError, PdDecodeFailure, PdSessionDecoder,
+};
 pub use uom;
+#[cfg(feature = "usbpd")]
+pub use usbpd;

--- a/km003c-lib/src/pd_decode.rs
+++ b/km003c-lib/src/pd_decode.rs
@@ -1,0 +1,253 @@
+//! Stateful semantic decoding of USB Power Delivery events.
+//!
+//! The KM003C-specific framing parser in [`crate::pd`] extracts standard USB PD
+//! wire messages. This module optionally decodes those messages through the
+//! `usbpd` crate while retaining the source capabilities and extended-message
+//! assembly state needed across events.
+
+use thiserror::Error;
+use uom::si::f64::Time;
+use usbpd::protocol_layer::message::data::Data;
+use usbpd::protocol_layer::message::data::source_capabilities::SourceCapabilities;
+use usbpd::protocol_layer::message::extended::chunked::{ChunkResult, ChunkedMessageAssembler};
+use usbpd::protocol_layer::message::header::{ExtendedMessageType, Header, MessageType};
+use usbpd::protocol_layer::message::{Message, ParseError, Payload};
+
+use crate::pd::{PdEvent, PdEventData};
+
+/// A semantically decoded USB PD message with its KM003C capture metadata.
+#[derive(Debug, Clone)]
+pub struct DecodedPdMessage {
+    pub timestamp: Time,
+    pub sop: u8,
+    pub message: Message,
+}
+
+/// Progress reported while handling a chunked USB PD extended message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PdChunkState {
+    Request { chunk_number: u8 },
+    Pending { received_chunk: u8, next_chunk: u8 },
+    Requested { chunk_number: u8 },
+    Unsupported { chunk_number: u8, data_size: u16 },
+}
+
+/// A chunked-message state change with its KM003C capture metadata.
+#[derive(Debug, Clone, Copy)]
+pub struct PdChunkStatus {
+    pub timestamp: Time,
+    pub sop: u8,
+    pub message_type: ExtendedMessageType,
+    pub state: PdChunkState,
+}
+
+/// Errors produced while semantically decoding an extracted USB PD message.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PdDecodeError {
+    #[error("USB PD wire message is empty")]
+    EmptyMessage,
+    #[error(transparent)]
+    Parse(#[from] ParseError),
+}
+
+/// A semantic decoding failure with the original wire bytes.
+#[derive(Debug, Clone)]
+pub struct PdDecodeFailure {
+    pub timestamp: Time,
+    pub sop: u8,
+    pub error: PdDecodeError,
+    pub wire_data: Vec<u8>,
+}
+
+/// Result of decoding one KM003C PD event.
+#[derive(Debug, Clone)]
+pub enum DecodedPdEvent {
+    Connect { timestamp: Time },
+    Disconnect { timestamp: Time },
+    Message(DecodedPdMessage),
+    Chunk(PdChunkStatus),
+    Error(PdDecodeFailure),
+}
+
+/// Stateful decoder for a sequence of KM003C USB PD events.
+///
+/// The decoder remembers SPR source capabilities so that subsequent Request
+/// messages can be interpreted using the selected PDO type. It also assembles
+/// chunked EPR Source Capabilities messages.
+#[derive(Debug, Clone, Default)]
+pub struct PdSessionDecoder {
+    source_capabilities: Option<SourceCapabilities>,
+    epr_assembler: ChunkedMessageAssembler,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ChunkDescriptor {
+    number: u8,
+    data_size: u16,
+    request: bool,
+    message_type: ExtendedMessageType,
+}
+
+impl PdSessionDecoder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Clear all connection-specific decoding state.
+    pub fn reset(&mut self) {
+        self.source_capabilities = None;
+        self.epr_assembler.reset();
+    }
+
+    /// Most recently observed SPR source capabilities.
+    pub fn source_capabilities(&self) -> Option<&SourceCapabilities> {
+        self.source_capabilities.as_ref()
+    }
+
+    /// Decode one KM003C PD event.
+    pub fn decode_event(&mut self, event: &PdEvent) -> DecodedPdEvent {
+        match &event.data {
+            PdEventData::Connect(()) => {
+                self.reset();
+                DecodedPdEvent::Connect {
+                    timestamp: event.timestamp,
+                }
+            }
+            PdEventData::Disconnect(()) => DecodedPdEvent::Disconnect {
+                timestamp: event.timestamp,
+            },
+            PdEventData::PdMessage { sop, wire_data } => self.decode_message(event.timestamp, *sop, wire_data),
+        }
+    }
+
+    fn decode_message(&mut self, timestamp: Time, sop: u8, wire_data: &[u8]) -> DecodedPdEvent {
+        if wire_data.is_empty() {
+            return self.failure(timestamp, sop, PdDecodeError::EmptyMessage, wire_data);
+        }
+
+        match parse_message_with_state(wire_data, self.source_capabilities.as_ref()) {
+            Ok(message) => {
+                if let Some(Payload::Data(Data::SourceCapabilities(capabilities))) = &message.payload {
+                    self.source_capabilities = Some(capabilities.clone());
+                }
+
+                DecodedPdEvent::Message(DecodedPdMessage {
+                    timestamp,
+                    sop,
+                    message,
+                })
+            }
+            Err(ParseError::ChunkedExtendedMessage {
+                chunk_number,
+                data_size,
+                request_chunk,
+                message_type,
+            }) => self.decode_chunk(
+                timestamp,
+                sop,
+                wire_data,
+                ChunkDescriptor {
+                    number: chunk_number,
+                    data_size,
+                    request: request_chunk,
+                    message_type,
+                },
+            ),
+            Err(error) => self.failure(timestamp, sop, error.into(), wire_data),
+        }
+    }
+
+    fn decode_chunk(&mut self, timestamp: Time, sop: u8, wire_data: &[u8], chunk: ChunkDescriptor) -> DecodedPdEvent {
+        if chunk.request {
+            return DecodedPdEvent::Chunk(PdChunkStatus {
+                timestamp,
+                sop,
+                message_type: chunk.message_type,
+                state: PdChunkState::Request {
+                    chunk_number: chunk.number,
+                },
+            });
+        }
+
+        if chunk.message_type != ExtendedMessageType::EprSourceCapabilities {
+            return DecodedPdEvent::Chunk(PdChunkStatus {
+                timestamp,
+                sop,
+                message_type: chunk.message_type,
+                state: PdChunkState::Unsupported {
+                    chunk_number: chunk.number,
+                    data_size: chunk.data_size,
+                },
+            });
+        }
+
+        let (header, extended_header, chunk_data) = match Message::parse_extended_chunk(wire_data) {
+            Ok(parts) => parts,
+            Err(error) => return self.failure(timestamp, sop, error.into(), wire_data),
+        };
+
+        match self.epr_assembler.process_chunk(header, extended_header, chunk_data) {
+            Ok(ChunkResult::Complete(data)) => {
+                let payload = Message::parse_extended_payload(chunk.message_type, &data);
+                DecodedPdEvent::Message(DecodedPdMessage {
+                    timestamp,
+                    sop,
+                    message: Message {
+                        header,
+                        payload: Some(Payload::Extended(payload)),
+                    },
+                })
+            }
+            Ok(ChunkResult::NeedMoreChunks(next_chunk)) => DecodedPdEvent::Chunk(PdChunkStatus {
+                timestamp,
+                sop,
+                message_type: chunk.message_type,
+                state: PdChunkState::Pending {
+                    received_chunk: chunk.number,
+                    next_chunk,
+                },
+            }),
+            Ok(ChunkResult::ChunkRequested(chunk_number)) => DecodedPdEvent::Chunk(PdChunkStatus {
+                timestamp,
+                sop,
+                message_type: chunk.message_type,
+                state: PdChunkState::Requested { chunk_number },
+            }),
+            Err(error) => {
+                self.epr_assembler.reset();
+                self.failure(timestamp, sop, error.into(), wire_data)
+            }
+        }
+    }
+
+    fn failure(&self, timestamp: Time, sop: u8, error: PdDecodeError, wire_data: &[u8]) -> DecodedPdEvent {
+        DecodedPdEvent::Error(PdDecodeFailure {
+            timestamp,
+            sop,
+            error,
+            wire_data: wire_data.to_vec(),
+        })
+    }
+}
+
+fn parse_message_with_state(
+    wire_data: &[u8],
+    source_capabilities: Option<&SourceCapabilities>,
+) -> Result<Message, ParseError> {
+    if wire_data.len() < 2 {
+        return Err(ParseError::InvalidLength {
+            expected: 2,
+            found: wire_data.len(),
+        });
+    }
+
+    let header = Header::from_bytes(&wire_data[..2])?;
+    let message = Message::new(header);
+
+    match header.message_type() {
+        MessageType::Data(message_type) => {
+            Data::parse_message(message, message_type, &wire_data[2..], &source_capabilities)
+        }
+        _ => Message::from_bytes(wire_data),
+    }
+}

--- a/km003c-lib/tests/pd_tests.rs
+++ b/km003c-lib/tests/pd_tests.rs
@@ -4,6 +4,17 @@ use uom::si::electric_current::milliampere;
 use uom::si::electric_potential::volt;
 use uom::si::time::millisecond;
 
+#[cfg(feature = "usbpd")]
+use km003c_lib::usbpd::protocol_layer::message::Payload;
+#[cfg(feature = "usbpd")]
+use km003c_lib::usbpd::protocol_layer::message::data::Data;
+#[cfg(feature = "usbpd")]
+use km003c_lib::usbpd::protocol_layer::message::data::request::PowerSource;
+#[cfg(feature = "usbpd")]
+use km003c_lib::usbpd::protocol_layer::message::extended::Extended;
+#[cfg(feature = "usbpd")]
+use km003c_lib::{DecodedPdEvent, PdChunkState, PdEvent, PdSessionDecoder};
+
 fn parse_pd_events(frame: &str) -> km003c_lib::PdEventStream {
     let raw = RawPacket::try_from(Bytes::from(hex::decode(frame).unwrap())).unwrap();
     Packet::try_from(raw).unwrap().get_pd_events().unwrap().clone()
@@ -117,4 +128,119 @@ fn rejects_event_size_smaller_than_protocol_offset() {
 
     let error = PdEventStream::from_bytes(Bytes::from(payload)).unwrap_err();
     assert!(error.to_string().contains("Invalid PD event size"));
+}
+
+#[cfg(feature = "usbpd")]
+#[test]
+fn semantically_decodes_recorded_pd_negotiation_with_source_state() {
+    // Source: usb_master_dataset.parquet, orig_with_pd.13, frame 714.
+    let stream = parse_pd_events(
+        "41a90205100000168bfa1200de130000750602009f80fa120000a1632c9101082cd102002cc103002cb10400454106003c21dcc08781fa12000041028b85fa1200008210dc7003238786fa1200002101878afa120000a305878afa1200004104",
+    );
+    let mut decoder = PdSessionDecoder::new();
+
+    let DecodedPdEvent::Message(source_caps) = decoder.decode_event(&stream.events[0]) else {
+        panic!("expected SourceCapabilities message");
+    };
+    assert!(matches!(
+        source_caps.message.payload,
+        Some(Payload::Data(Data::SourceCapabilities(_)))
+    ));
+    assert!(decoder.source_capabilities().is_some());
+
+    let DecodedPdEvent::Message(request) = decoder.decode_event(&stream.events[2]) else {
+        panic!("expected Request message");
+    };
+    assert!(matches!(
+        request.message.payload,
+        Some(Payload::Data(Data::Request(
+            PowerSource::FixedVariableSupply(_) | PowerSource::Battery(_) | PowerSource::Pps(_) | PowerSource::Avs(_)
+        )))
+    ));
+}
+
+#[cfg(feature = "usbpd")]
+#[test]
+fn connection_event_resets_semantic_decoder_state() {
+    let stream = parse_pd_events(
+        "41a90205100000168bfa1200de130000750602009f80fa120000a1632c9101082cd102002cc103002cb10400454106003c21dcc08781fa12000041028b85fa1200008210dc7003238786fa1200002101878afa120000a305878afa1200004104",
+    );
+    let mut decoder = PdSessionDecoder::new();
+    decoder.decode_event(&stream.events[0]);
+    assert!(decoder.source_capabilities().is_some());
+
+    let connect = PdEvent {
+        timestamp: uom::si::f64::Time::new::<millisecond>(1_250_000.0),
+        data: PdEventData::Connect(()),
+    };
+    assert!(matches!(decoder.decode_event(&connect), DecodedPdEvent::Connect { .. }));
+    assert!(decoder.source_capabilities().is_none());
+}
+
+#[cfg(feature = "usbpd")]
+#[test]
+fn assembles_recorded_chunked_epr_source_capabilities() {
+    // Captured EPR Source Capabilities split into two USB PD extended-message chunks.
+    let chunks = [
+        vec![
+            0xB1, 0xFD, 0x28, 0x80, 0x2C, 0x91, 0x91, 0x0A, 0x2C, 0xD1, 0x12, 0x00, 0x2C, 0xC1, 0x13, 0x00, 0x2C, 0xB1,
+            0x14, 0x00, 0xF4, 0x41, 0x16, 0x00, 0x64, 0x32, 0xA4, 0xC9, 0x00, 0x00,
+        ],
+        vec![
+            0xB1, 0xCF, 0x28, 0x88, 0x00, 0x00, 0xF4, 0xC1, 0x18, 0x00, 0xF4, 0x41, 0x1B, 0x00, 0xF4, 0x01, 0x1F, 0x00,
+        ],
+    ];
+    let mut decoder = PdSessionDecoder::new();
+
+    let first = PdEvent {
+        timestamp: uom::si::f64::Time::new::<millisecond>(1.0),
+        data: PdEventData::PdMessage {
+            sop: 0,
+            wire_data: chunks[0].clone(),
+        },
+    };
+    let DecodedPdEvent::Chunk(status) = decoder.decode_event(&first) else {
+        panic!("expected pending chunk status");
+    };
+    assert_eq!(
+        status.state,
+        PdChunkState::Pending {
+            received_chunk: 0,
+            next_chunk: 1,
+        }
+    );
+
+    let second = PdEvent {
+        timestamp: uom::si::f64::Time::new::<millisecond>(2.0),
+        data: PdEventData::PdMessage {
+            sop: 0,
+            wire_data: chunks[1].clone(),
+        },
+    };
+    let DecodedPdEvent::Message(message) = decoder.decode_event(&second) else {
+        panic!("expected assembled EPR SourceCapabilities");
+    };
+    let Some(Payload::Extended(Extended::EprSourceCapabilities(pdos))) = message.message.payload else {
+        panic!("expected EPR SourceCapabilities payload");
+    };
+    assert_eq!(pdos.len(), 10);
+}
+
+#[cfg(feature = "usbpd")]
+#[test]
+fn reports_short_wire_messages_without_panicking() {
+    let event = PdEvent {
+        timestamp: uom::si::f64::Time::new::<millisecond>(1.0),
+        data: PdEventData::PdMessage {
+            sop: 0,
+            wire_data: vec![0x01],
+        },
+    };
+    let mut decoder = PdSessionDecoder::new();
+
+    let DecodedPdEvent::Error(failure) = decoder.decode_event(&event) else {
+        panic!("expected decode failure");
+    };
+    assert!(failure.error.to_string().contains("expected 2"));
+    assert_eq!(failure.wire_data, vec![0x01]);
 }


### PR DESCRIPTION
## Summary

- add an optional `usbpd` feature and typed `PdSessionDecoder` API to `km003c-lib`
- preserve Source Capabilities state for typed Request decoding and reassemble chunked EPR Source Capabilities
- migrate `km003c-egui` and `test_usbpd` to the shared decoder while keeping presentation formatting in each app
- fix the egui PD connection indicator flickering and misreporting an open CC line as an attached phone
- add capture-backed decoder and connection-state regression tests

## Fixes

The egui connection label previously treated any CC voltage above 0.2 V as connected. That is not valid for the KM003C's downstream/source-facing CC pins: the recorded unattached state has an open source CC line near 3.237 V, while an attached sink's Rd pulls the active line to about 1.654 V.

The GUI now:

- consumes the current `PdStatus` preamble from event-stream packets instead of discarding it
- uses protocol-level connect/disconnect events once available
- applies 100 ms debounce and a capture-backed fallback range: 0.20–2.45 V means an attached Rd, while ≤0.10 V or ≥2.75 V means unattached
- does not color an open 3.2 V CC line as connected
- resets PD status when the KM003C itself disconnects

## Decoder refactor

Semantic USB PD parsing already existed in the GUI and CLI, but each application maintained its own Source Capabilities and EPR chunk state. The library only exposed KM003C framing and raw wire bytes, which duplicated protocol logic and allowed behavior to drift.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`
- `cargo package -p km003c-lib --allow-dirty`
- packaged crate checked with `--all-features` against crates.io dependencies