### PR TITLE
Fix incorrect protocol decoding and device session handling

### DIFF
--- a/km003c-cli/src/bin/adc_simple.rs
+++ b/km003c-cli/src/bin/adc_simple.rs
@@ -113,7 +113,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Sample rate and internal voltage
     println!("\n⚙️  Device Info:");
-    println!("  Sample Rate: {}", adc_data.sample_rate);
+    match adc_data.sample_rate {
+        Some(rate) => println!("  Sample Rate: {rate}"),
+        None => println!("  Sample Rate: Unknown ({})", adc_data.sample_rate_raw),
+    }
     println!("  Internal VDD: {:>7.3} V", adc_data.internal_vdd.get::<volt>());
 
     println!("\n{}", "=".repeat(50));

--- a/km003c-cli/src/bin/memory_scan.rs
+++ b/km003c-cli/src/bin/memory_scan.rs
@@ -1,4 +1,5 @@
-use km003c_lib::{DeviceConfig, KM003C, Packet};
+use clap::Parser;
+use km003c_lib::{DeviceConfig, KM003C, error::KMError};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
@@ -10,6 +11,39 @@ enum ReadResult {
     Data(usize),
     Timeout,
     Error(String),
+}
+
+/// Read documented KM003C memory regions or explicitly scan additional addresses.
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// Read one address instead of the documented regions (decimal or 0x-prefixed hex).
+    #[arg(long, value_parser = parse_address)]
+    address: Option<u32>,
+
+    /// Number of bytes to read with --address.
+    #[arg(long, default_value_t = 64)]
+    size: u32,
+
+    /// Probe undocumented address ranges after reading documented regions.
+    #[arg(long)]
+    full_scan: bool,
+
+    /// Skip USB reset (defaults to true on macOS for compatibility).
+    #[arg(long, default_value_t = cfg!(target_os = "macos"))]
+    no_reset: bool,
+
+    /// Force USB reset even on macOS (overrides --no-reset).
+    #[arg(long)]
+    reset: bool,
+}
+
+fn parse_address(value: &str) -> Result<u32, String> {
+    if let Some(hex) = value.strip_prefix("0x").or_else(|| value.strip_prefix("0X")) {
+        u32::from_str_radix(hex, 16).map_err(|error| error.to_string())
+    } else {
+        value.parse::<u32>().map_err(|error| error.to_string())
+    }
 }
 
 impl std::fmt::Display for ReadResult {
@@ -26,17 +60,27 @@ impl std::fmt::Display for ReadResult {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
     tracing_subscriber::fmt::init();
 
     println!("KM003C Memory Scanner");
     println!("=====================\n");
 
-    // Connect with no-reset to avoid disturbing the device too much
-    let config = DeviceConfig::vendor().skip_reset();
+    let config = if args.no_reset && !args.reset {
+        DeviceConfig::vendor().skip_reset()
+    } else {
+        DeviceConfig::vendor()
+    };
     let mut device = KM003C::new(config).await?;
 
     let state = device.state().expect("device initialized");
     println!("{}\n", state);
+
+    if let Some(address) = args.address {
+        let result = try_read(&mut device, address, args.size).await;
+        println!("0x{address:08X} ({} bytes requested): {result}", args.size);
+        return Ok(());
+    }
 
     // Track results by address
     let mut results: BTreeMap<u32, ReadResult> = BTreeMap::new();
@@ -58,6 +102,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         results.insert(*addr, result);
         // Small delay to avoid overwhelming the device
         tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    if !args.full_scan {
+        println!("\nPass --full-scan to probe undocumented address ranges.");
+        return Ok(());
     }
 
     println!("\n\nScanning memory regions...\n");
@@ -149,29 +198,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn try_read(device: &mut KM003C, address: u32, size: u32) -> ReadResult {
-    // Send MemoryRead request
-    if let Err(e) = device.send(Packet::MemoryRead { address, size }).await {
-        return ReadResult::Error(format!("send: {}", e));
+    match device.read_memory_block(address, size).await {
+        Ok(data) => ReadResult::Data(data.len()),
+        Err(KMError::Timeout(_)) => ReadResult::Timeout,
+        Err(KMError::Protocol(message)) if message.contains("not readable") => ReadResult::NotReadable,
+        Err(KMError::Protocol(message)) if message.contains("rejected") => ReadResult::Reject,
+        Err(error) => ReadResult::Error(error.to_string()),
     }
+}
 
-    // Wait for confirmation packet (0xC4 = Accept) or error response
-    match tokio::time::timeout(Duration::from_millis(500), device.receive()).await {
-        Ok(Ok(packet)) => match packet {
-            Packet::Accept { .. } => {
-                // Accept means confirmation received, now get encrypted data
-                // receive_memory_read_data() handles decryption
-                match tokio::time::timeout(Duration::from_millis(500), device.receive_memory_read_data()).await {
-                    Ok(Ok(Packet::MemoryReadResponse { data })) => ReadResult::Data(data.len()),
-                    Ok(Ok(other)) => ReadResult::Error(format!("unexpected after confirm: {:?}", other)),
-                    Ok(Err(e)) => ReadResult::Error(format!("data recv: {}", e)),
-                    Err(_) => ReadResult::Timeout,
-                }
-            }
-            Packet::NotReadable { .. } => ReadResult::NotReadable,
-            Packet::Reject { .. } => ReadResult::Reject,
-            other => ReadResult::Error(format!("unexpected: {:?}", other)),
-        },
-        Ok(Err(e)) => ReadResult::Error(format!("recv: {}", e)),
-        Err(_) => ReadResult::Timeout,
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_decimal_and_hex_addresses() {
+        assert_eq!(parse_address("1056").unwrap(), 0x420);
+        assert_eq!(parse_address("0x40010450").unwrap(), 0x4001_0450);
+        assert!(parse_address("0xnope").is_err());
     }
 }

--- a/km003c-cli/src/bin/test_usbpd.rs
+++ b/km003c-cli/src/bin/test_usbpd.rs
@@ -56,6 +56,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let state = device.state().expect("vendor interface provides state");
     println!("{state}\n");
 
+    device.enable_pd_monitor().await?;
+
     println!("USB PD Negotiation Capture");
     println!("NOW: Disconnect and reconnect your USB-C load!");
     println!(
@@ -96,6 +98,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    device.disable_pd_monitor().await?;
     device.send(Packet::Disconnect).await?;
     println!("\nCapture complete.");
     Ok(())

--- a/km003c-lib/src/adc.rs
+++ b/km003c-lib/src/adc.rs
@@ -107,6 +107,10 @@ pub struct AdcDataSimple {
     // Averaged measurements
     pub vbus_average: ElectricPotential,
     pub ibus_average: ElectricCurrent,
+    /// Uncalibrated VBUS average preserved verbatim from the device.
+    pub vbus_uncalibrated_average_raw: i32,
+    /// Uncalibrated IBUS average preserved verbatim from the device.
+    pub ibus_uncalibrated_average_raw: i32,
 
     // Temperature
     pub temperature: ThermodynamicTemperature,
@@ -125,8 +129,12 @@ pub struct AdcDataSimple {
     // Internal voltage
     pub internal_vdd: ElectricPotential,
 
-    // Sample rate
-    pub sample_rate: SampleRate, // Sample rate as enum
+    /// Known sample rate, or `None` when the device reports an unknown index.
+    pub sample_rate: Option<SampleRate>,
+    /// Original sample-rate index, retained for lossless parsing and serialization.
+    pub sample_rate_raw: u8,
+    /// Opaque vendor flags preserved from the ADC payload.
+    pub vendor_flags: u8,
 }
 
 impl From<AdcDataRaw> for AdcDataSimple {
@@ -134,8 +142,7 @@ impl From<AdcDataRaw> for AdcDataSimple {
         let vbus = ElectricPotential::new::<microvolt>(f64::from(raw.vbus_uv.get()));
         let ibus = ElectricCurrent::new::<microampere>(f64::from(raw.ibus_ua.get()));
 
-        // Convert raw sample rate to enum (safely, fallback to 2 SPS if invalid)
-        let sample_rate = SampleRate::try_from(raw.rate_raw).unwrap_or(SampleRate::Sps2);
+        let sample_rate = SampleRate::try_from(raw.rate_raw).ok();
 
         AdcDataSimple {
             vbus,
@@ -143,6 +150,8 @@ impl From<AdcDataRaw> for AdcDataSimple {
             power: vbus * ibus,
             vbus_average: ElectricPotential::new::<microvolt>(f64::from(raw.vbus_avg_uv.get())),
             ibus_average: ElectricCurrent::new::<microampere>(f64::from(raw.ibus_avg_ua.get())),
+            vbus_uncalibrated_average_raw: raw.vbus_ori_avg_raw.get(),
+            ibus_uncalibrated_average_raw: raw.ibus_ori_avg_raw.get(),
             temperature: ThermodynamicTemperature::new::<degree_celsius>(f64::from(raw.temp_raw.get()) / 128.0),
             vdp: ElectricPotential::new::<millivolt>(f64::from(raw.vdp_mv.get()) / 10.0),
             vdm: ElectricPotential::new::<millivolt>(f64::from(raw.vdm_mv.get()) / 10.0),
@@ -153,6 +162,8 @@ impl From<AdcDataRaw> for AdcDataSimple {
             cc2_average: ElectricPotential::new::<millivolt>(f64::from(raw.vcc2_avg_raw.get())),
             internal_vdd: ElectricPotential::new::<millivolt>(f64::from(raw.internal_vdd_raw.get()) / 10.0),
             sample_rate,
+            sample_rate_raw: raw.rate_raw,
+            vendor_flags: raw.reserved,
         }
     }
 }
@@ -160,25 +171,25 @@ impl From<AdcDataRaw> for AdcDataSimple {
 impl From<AdcDataSimple> for AdcDataRaw {
     fn from(data: AdcDataSimple) -> Self {
         AdcDataRaw {
-            vbus_uv: I32::new(data.vbus.get::<microvolt>() as i32),
-            ibus_ua: I32::new(data.ibus.get::<microampere>() as i32),
-            vbus_avg_uv: I32::new(data.vbus_average.get::<microvolt>() as i32),
-            ibus_avg_ua: I32::new(data.ibus_average.get::<microampere>() as i32),
-            vbus_ori_avg_raw: I32::new(0), // We don't have this information
-            ibus_ori_avg_raw: I32::new(0), // We don't have this information
+            vbus_uv: I32::new(data.vbus.get::<microvolt>().round() as i32),
+            ibus_ua: I32::new(data.ibus.get::<microampere>().round() as i32),
+            vbus_avg_uv: I32::new(data.vbus_average.get::<microvolt>().round() as i32),
+            ibus_avg_ua: I32::new(data.ibus_average.get::<microampere>().round() as i32),
+            vbus_ori_avg_raw: I32::new(data.vbus_uncalibrated_average_raw),
+            ibus_ori_avg_raw: I32::new(data.ibus_uncalibrated_average_raw),
             // Encode temperature back to raw register: °C * 128
-            temp_raw: I16::new((data.temperature.get::<degree_celsius>() * 128.0) as i16),
-            vcc1_tenth_mv: U16::new((data.cc1.get::<millivolt>() * 10.0) as u16),
-            vcc2_raw: U16::new((data.cc2.get::<millivolt>() * 10.0) as u16),
-            vdp_mv: U16::new((data.vdp.get::<millivolt>() * 10.0) as u16),
-            vdm_mv: U16::new((data.vdm.get::<millivolt>() * 10.0) as u16),
-            internal_vdd_raw: U16::new((data.internal_vdd.get::<millivolt>() * 10.0) as u16),
-            rate_raw: data.sample_rate as u8,
-            reserved: 0,
+            temp_raw: I16::new((data.temperature.get::<degree_celsius>() * 128.0).round() as i16),
+            vcc1_tenth_mv: U16::new((data.cc1.get::<millivolt>() * 10.0).round() as u16),
+            vcc2_raw: U16::new((data.cc2.get::<millivolt>() * 10.0).round() as u16),
+            vdp_mv: U16::new((data.vdp.get::<millivolt>() * 10.0).round() as u16),
+            vdm_mv: U16::new((data.vdm.get::<millivolt>() * 10.0).round() as u16),
+            internal_vdd_raw: U16::new((data.internal_vdd.get::<millivolt>() * 10.0).round() as u16),
+            rate_raw: data.sample_rate.map_or(data.sample_rate_raw, u8::from),
+            reserved: data.vendor_flags,
             // Store averaged fields in 1 mV units
-            vcc2_avg_raw: U16::new(data.cc2_average.get::<millivolt>() as u16),
-            vdp_avg_mv: U16::new(data.vdp_average.get::<millivolt>() as u16),
-            vdm_avg_mv: U16::new(data.vdm_average.get::<millivolt>() as u16),
+            vcc2_avg_raw: U16::new(data.cc2_average.get::<millivolt>().round() as u16),
+            vdp_avg_mv: U16::new(data.vdp_average.get::<millivolt>().round() as u16),
+            vdm_avg_mv: U16::new(data.vdm_average.get::<millivolt>().round() as u16),
         }
     }
 }
@@ -204,7 +215,10 @@ impl fmt::Display for AdcDataSimple {
             self.ibus.get::<ampere>(),
             self.power.get::<watt>(),
             self.temperature.get::<degree_celsius>(),
-            self.sample_rate
+            self.sample_rate.map_or_else(
+                || format!("Unknown ({})", self.sample_rate_raw),
+                |rate| rate.to_string()
+            )
         )
     }
 }
@@ -269,8 +283,24 @@ impl AdcDataSimple {
         self.internal_vdd.get::<volt>()
     }
     #[getter]
-    fn sample_rate(&self) -> SampleRate {
+    fn sample_rate(&self) -> Option<SampleRate> {
         self.sample_rate
+    }
+    #[getter]
+    fn sample_rate_raw(&self) -> u8 {
+        self.sample_rate_raw
+    }
+    #[getter]
+    fn vendor_flags(&self) -> u8 {
+        self.vendor_flags
+    }
+    #[getter]
+    fn vbus_uncalibrated_average_raw(&self) -> i32 {
+        self.vbus_uncalibrated_average_raw
+    }
+    #[getter]
+    fn ibus_uncalibrated_average_raw(&self) -> i32 {
+        self.ibus_uncalibrated_average_raw
     }
 
     fn __repr__(&self) -> String {

--- a/km003c-lib/src/adcqueue.rs
+++ b/km003c-lib/src/adcqueue.rs
@@ -19,6 +19,7 @@ use uom::si::{electric_current::ampere, electric_potential::volt, power::watt};
 /// Used with StartGraph (0x0E) command to configure device sampling rate.
 /// The device expects the rate index directly (0-3).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromPrimitive)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(u16)]
 pub enum GraphSampleRate {
     /// 2 samples per second
@@ -119,7 +120,7 @@ impl fmt::Display for GraphSampleRate {
 /// - VDD (internal voltage)
 #[derive(Debug, Clone, Copy, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
 #[repr(C)]
-pub struct AdcQueueSampleRaw {
+struct AdcQueueSampleWire {
     /// Incrementing sequence number for detecting dropped samples
     pub sequence: U16,
     /// Marker/flags field (varies by firmware version and mode, not temperature)
@@ -138,12 +139,130 @@ pub struct AdcQueueSampleRaw {
     pub vdm_raw: U16,
 }
 
+/// Lossless raw AdcQueue sample.
+///
+/// The four auxiliary-line fields are device counts rather than voltages.
+/// Converting them requires the sample rate selected by `StartGraph`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "python", pyo3::pyclass(get_all, skip_from_py_object))]
+pub struct AdcQueueSampleRaw {
+    pub sequence: u16,
+    pub marker: u16,
+    pub vbus_uv: i32,
+    pub ibus_ua: i32,
+    pub cc1_raw: u16,
+    pub cc2_raw: u16,
+    pub vdp_raw: u16,
+    pub vdm_raw: u16,
+}
+
+impl From<AdcQueueSampleWire> for AdcQueueSampleRaw {
+    fn from(raw: AdcQueueSampleWire) -> Self {
+        Self {
+            sequence: raw.sequence.get(),
+            marker: raw.marker.get(),
+            vbus_uv: raw.vbus_uv.get(),
+            ibus_ua: raw.ibus_ua.get(),
+            cc1_raw: raw.cc1_raw.get(),
+            cc2_raw: raw.cc2_raw.get(),
+            vdp_raw: raw.vdp_raw.get(),
+            vdm_raw: raw.vdm_raw.get(),
+        }
+    }
+}
+
+impl From<AdcQueueSampleRaw> for AdcQueueSampleWire {
+    fn from(raw: AdcQueueSampleRaw) -> Self {
+        Self {
+            sequence: U16::new(raw.sequence),
+            marker: U16::new(raw.marker),
+            vbus_uv: I32::new(raw.vbus_uv),
+            ibus_ua: I32::new(raw.ibus_ua),
+            cc1_raw: U16::new(raw.cc1_raw),
+            cc2_raw: U16::new(raw.cc2_raw),
+            vdp_raw: U16::new(raw.vdp_raw),
+            vdm_raw: U16::new(raw.vdm_raw),
+        }
+    }
+}
+
+/// AdcQueue payload parsed without guessing the graph sample rate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "python", pyo3::pyclass(skip_from_py_object))]
+pub struct AdcQueueRawData {
+    pub samples: Vec<AdcQueueSampleRaw>,
+}
+
+impl AdcQueueRawData {
+    const SAMPLE_SIZE: usize = 20;
+
+    /// Parse a payload losslessly without assigning units to auxiliary counts.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, crate::error::KMError> {
+        if !bytes.len().is_multiple_of(Self::SAMPLE_SIZE) {
+            return Err(crate::error::KMError::InvalidPacket(format!(
+                "AdcQueue payload length must be a multiple of {}, got {}",
+                Self::SAMPLE_SIZE,
+                bytes.len()
+            )));
+        }
+
+        let samples = bytes
+            .chunks_exact(Self::SAMPLE_SIZE)
+            .map(|sample| {
+                AdcQueueSampleWire::ref_from_bytes(sample)
+                    .map(|wire| AdcQueueSampleRaw::from(*wire))
+                    .map_err(|_| crate::error::KMError::InvalidPacket("Failed to parse AdcQueue sample".to_string()))
+            })
+            .collect::<Result<_, _>>()?;
+
+        Ok(Self { samples })
+    }
+
+    /// Convert raw auxiliary counts using an explicitly known graph rate.
+    pub fn decode(&self, rate: GraphSampleRate) -> AdcQueueData {
+        AdcQueueData {
+            rate,
+            samples: self
+                .samples
+                .iter()
+                .copied()
+                .map(|sample| AdcQueueSample::from_raw(sample, rate))
+                .collect(),
+        }
+    }
+
+    pub fn sequence_range(&self) -> Option<(u16, u16)> {
+        self.samples
+            .first()
+            .zip(self.samples.last())
+            .map(|(first, last)| (first.sequence, last.sequence))
+    }
+
+    pub fn has_dropped_samples(&self, rate: GraphSampleRate) -> bool {
+        self.samples
+            .windows(2)
+            .any(|window| rate.missing_samples(window[0].sequence, window[1].sequence) > 0)
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.samples
+            .iter()
+            .copied()
+            .flat_map(|sample| AdcQueueSampleWire::from(sample).as_bytes().to_vec())
+            .collect()
+    }
+}
+
 /// Parsed AdcQueue sample with converted units
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "python", pyo3::pyclass(skip_from_py_object, name = "AdcQueueSample"))]
 pub struct AdcQueueSample {
     pub sequence: u16,
+    /// Opaque device marker/flags preserved from the wire sample.
+    pub marker: u16,
     pub vbus: ElectricPotential,
     pub ibus: ElectricCurrent,
     pub power: Power,
@@ -156,19 +275,20 @@ pub struct AdcQueueSample {
 impl AdcQueueSample {
     /// Convert a raw sample using the units for the configured graph rate.
     pub fn from_raw(raw: AdcQueueSampleRaw, rate: GraphSampleRate) -> Self {
-        let vbus = ElectricPotential::new::<microvolt>(f64::from(raw.vbus_uv.get()));
-        let ibus = ElectricCurrent::new::<microampere>(f64::from(raw.ibus_ua.get()));
+        let vbus = ElectricPotential::new::<microvolt>(f64::from(raw.vbus_uv));
+        let ibus = ElectricCurrent::new::<microampere>(f64::from(raw.ibus_ua));
         let auxiliary_voltage_lsb = rate.auxiliary_voltage_lsb();
 
         Self {
-            sequence: raw.sequence.get(),
+            sequence: raw.sequence,
+            marker: raw.marker,
             vbus,
             ibus,
             power: vbus * ibus,
-            cc1: auxiliary_voltage_lsb * f64::from(raw.cc1_raw.get()),
-            cc2: auxiliary_voltage_lsb * f64::from(raw.cc2_raw.get()),
-            vdp: auxiliary_voltage_lsb * f64::from(raw.vdp_raw.get()),
-            vdm: auxiliary_voltage_lsb * f64::from(raw.vdm_raw.get()),
+            cc1: auxiliary_voltage_lsb * f64::from(raw.cc1_raw),
+            cc2: auxiliary_voltage_lsb * f64::from(raw.cc2_raw),
+            vdp: auxiliary_voltage_lsb * f64::from(raw.vdp_raw),
+            vdm: auxiliary_voltage_lsb * f64::from(raw.vdm_raw),
         }
     }
 }
@@ -176,90 +296,42 @@ impl AdcQueueSample {
 /// Complete AdcQueue response containing multiple buffered samples
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(
-    feature = "python",
-    pyo3::pyclass(get_all, skip_from_py_object, name = "AdcQueueData")
-)]
+#[cfg_attr(feature = "python", pyo3::pyclass(skip_from_py_object, name = "AdcQueueData"))]
 pub struct AdcQueueData {
+    pub rate: GraphSampleRate,
     pub samples: Vec<AdcQueueSample>,
 }
 
 impl AdcQueueData {
-    /// Parse AdcQueue payload containing multiple 20-byte samples
-    ///
-    /// Note: Some firmware versions may return payloads not divisible by 20.
-    /// In this case, we parse as many complete samples as possible.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, crate::error::KMError> {
-        let rate = Self::infer_rate(bytes).unwrap_or(GraphSampleRate::Sps2);
-        Self::from_bytes_with_rate(bytes, rate)
-    }
-
     /// Parse AdcQueue payload using the explicitly configured graph rate.
-    ///
-    /// Prefer this method for live device traffic. [`Self::from_bytes`] infers
-    /// the rate from adjacent sequence values, but a one-sample payload does
-    /// not carry enough information and falls back to the 2 SPS scale.
     pub fn from_bytes_with_rate(bytes: &[u8], rate: GraphSampleRate) -> Result<Self, crate::error::KMError> {
-        const SAMPLE_SIZE: usize = 20;
-
-        // Take as many complete samples as we can
-        let num_samples = bytes.len() / SAMPLE_SIZE;
-        let mut samples = Vec::with_capacity(num_samples);
-
-        for i in 0..num_samples {
-            let offset = i * SAMPLE_SIZE;
-            let sample_raw = AdcQueueSampleRaw::ref_from_bytes(&bytes[offset..offset + SAMPLE_SIZE])
-                .map_err(|_| crate::error::KMError::InvalidPacket("Failed to parse AdcQueue sample".to_string()))?;
-
-            samples.push(AdcQueueSample::from_raw(*sample_raw, rate));
-        }
-
-        Ok(Self { samples })
-    }
-
-    fn infer_rate(bytes: &[u8]) -> Option<GraphSampleRate> {
-        const SAMPLE_SIZE: usize = 20;
-
-        let mut sequences = bytes
-            .chunks_exact(SAMPLE_SIZE)
-            .filter_map(|sample| AdcQueueSampleRaw::ref_from_bytes(sample).ok())
-            .map(|sample| sample.sequence.get());
-        let mut previous = sequences.next()?;
-
-        for current in sequences {
-            let step = current.wrapping_sub(previous);
-            if let Some(rate) = GraphSampleRate::from_sequence_step(step) {
-                return Some(rate);
-            }
-            previous = current;
-        }
-
-        None
+        Ok(AdcQueueRawData::from_bytes(bytes)?.decode(rate))
     }
 
     /// Get the sequence number range of samples in this queue
     pub fn sequence_range(&self) -> Option<(u16, u16)> {
-        if self.samples.is_empty() {
-            None
-        } else {
-            Some((
-                self.samples.first().unwrap().sequence,
-                self.samples.last().unwrap().sequence,
-            ))
-        }
+        self.samples
+            .first()
+            .zip(self.samples.last())
+            .map(|(first, last)| (first.sequence, last.sequence))
     }
 
-    /// Check for dropped samples using the sequence step for `rate`.
-    pub fn has_dropped_samples(&self, rate: GraphSampleRate) -> bool {
+    /// Check for dropped samples using the configured graph rate.
+    pub fn has_dropped_samples(&self) -> bool {
         self.samples
             .windows(2)
-            .any(|window| rate.missing_samples(window[0].sequence, window[1].sequence) > 0)
+            .any(|window| self.rate.missing_samples(window[0].sequence, window[1].sequence) > 0)
     }
 }
 
 #[cfg(feature = "python")]
 #[pyo3::pymethods]
-impl AdcQueueData {
+impl AdcQueueRawData {
+    #[getter]
+    fn samples(&self) -> Vec<AdcQueueSampleRaw> {
+        self.samples.clone()
+    }
+
     #[pyo3(name = "sequence_range")]
     fn py_sequence_range(&self) -> Option<(u16, u16)> {
         self.sequence_range()
@@ -271,6 +343,38 @@ impl AdcQueueData {
             pyo3::exceptions::PyValueError::new_err(format!("Invalid graph sample rate index: {rate_index}"))
         })?;
         Ok(self.has_dropped_samples(rate))
+    }
+
+    fn __repr__(&self) -> String {
+        format!("AdcQueueRawData({} samples)", self.samples.len())
+    }
+
+    fn __str__(&self) -> String {
+        self.__repr__()
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyo3::pymethods]
+impl AdcQueueData {
+    #[getter]
+    fn rate_index(&self) -> u16 {
+        self.rate as u16
+    }
+
+    #[getter]
+    fn samples(&self) -> Vec<AdcQueueSample> {
+        self.samples.clone()
+    }
+
+    #[pyo3(name = "sequence_range")]
+    fn py_sequence_range(&self) -> Option<(u16, u16)> {
+        self.sequence_range()
+    }
+
+    #[pyo3(name = "has_dropped_samples")]
+    fn py_has_dropped_samples(&self) -> bool {
+        self.has_dropped_samples()
     }
 
     fn __repr__(&self) -> String {
@@ -288,6 +392,10 @@ impl AdcQueueSample {
     #[getter]
     fn sequence(&self) -> u16 {
         self.sequence
+    }
+    #[getter]
+    fn marker(&self) -> u16 {
+        self.marker
     }
     #[getter]
     fn vbus_v(&self) -> f64 {

--- a/km003c-lib/src/device.rs
+++ b/km003c-lib/src/device.rs
@@ -282,6 +282,18 @@ pub enum ConnectionMode {
     Full(DeviceState),
 }
 
+fn ensure_adcqueue_available(mode: &ConnectionMode) -> Result<(), KMError> {
+    match mode {
+        ConnectionMode::Basic => Err(KMError::Protocol(
+            "AdcQueue streaming requires Full mode (vendor interface)".to_string(),
+        )),
+        ConnectionMode::Full(state) if !state.adcqueue_enabled => Err(KMError::Protocol(
+            "StreamingAuth did not enable AdcQueue streaming".to_string(),
+        )),
+        ConnectionMode::Full(_) => Ok(()),
+    }
+}
+
 /// Configuration for KM003C device communication
 ///
 /// Specifies which USB interface to use. The interface determines the connection mode:
@@ -1123,7 +1135,7 @@ impl KM003C {
     /// # Arguments
     /// * `rate` - Sample rate (use GraphSampleRate enum)
     ///
-    /// **Requires Full mode** (vendor interface). Will return error in Basic mode.
+    /// **Requires Full mode** (vendor interface) and successful StreamingAuth.
     ///
     /// Rate values:
     /// - `GraphSampleRate::Sps2` = 2 samples per second
@@ -1151,11 +1163,7 @@ impl KM003C {
     /// # }
     /// ```
     pub async fn start_graph_mode(&mut self, rate: GraphSampleRate) -> Result<(), KMError> {
-        if self.is_basic_mode() {
-            return Err(KMError::Protocol(
-                "AdcQueue streaming requires Full mode (vendor interface)".to_string(),
-            ));
-        }
+        ensure_adcqueue_available(&self.mode)?;
 
         // Device expects rate index directly: 0=2SPS, 1=10SPS, 2=50SPS, 3=1000SPS
         let id = self
@@ -1194,6 +1202,26 @@ mod tests {
     #[test]
     fn response_matching_uses_the_typed_header_parser() {
         assert!(response_matches(&[0xc1, 7, 0, 0], 7, PacketType::PutData));
+    }
+
+    #[test]
+    fn graph_mode_requires_streaming_auth_permission() {
+        assert!(ensure_adcqueue_available(&ConnectionMode::Basic).is_err());
+
+        let state = DeviceState {
+            info: DeviceInfo::default(),
+            hardware_id: HardwareId::from_bytes([0; 12]),
+            auth_level: 0,
+            adcqueue_enabled: false,
+        };
+        assert!(ensure_adcqueue_available(&ConnectionMode::Full(state.clone())).is_err());
+
+        let enabled = DeviceState {
+            auth_level: 1,
+            adcqueue_enabled: true,
+            ..state
+        };
+        assert!(ensure_adcqueue_available(&ConnectionMode::Full(enabled)).is_ok());
     }
 
     #[test]

--- a/km003c-lib/src/device.rs
+++ b/km003c-lib/src/device.rs
@@ -200,6 +200,20 @@ fn append_memory_chunk(buffer: &mut Vec<u8>, chunk: &[u8], expected_size: usize)
     Ok(buffer.len() == expected_size)
 }
 
+fn decrypt_memory_response(encrypted: &[u8], requested_size: u32) -> Result<Vec<u8>, KMError> {
+    let expected_size = memory_response_size(requested_size);
+    if encrypted.len() != expected_size {
+        return Err(KMError::Protocol(format!(
+            "Encrypted memory response has the wrong size: expected {expected_size} bytes, got {}",
+            encrypted.len()
+        )));
+    }
+
+    let mut decrypted = crate::auth::aes_ecb_decrypt_blocks(encrypted, crate::auth::MEMORY_READ_KEY)?;
+    decrypted.truncate(requested_size as usize);
+    Ok(decrypted)
+}
+
 fn validate_memory_read_confirmation(
     packet: &RawPacket,
     expected_id: u8,
@@ -791,7 +805,7 @@ impl KM003C {
             }
         }
 
-        crate::auth::aes_ecb_decrypt_blocks(&encrypted, crate::auth::MEMORY_READ_KEY)
+        decrypt_memory_response(&encrypted, requested_size)
     }
 
     /// Request data with a specific attribute set
@@ -1017,9 +1031,8 @@ impl KM003C {
     /// Read an encrypted memory block from the device
     ///
     /// Sends a MemoryRead request, receives the confirmation, then receives
-    /// and decrypts the actual data. Returns the decrypted bytes.
-    ///
-    /// Response size is rounded up to 16-byte boundary (AES block size).
+    /// and decrypts the actual data. Returns exactly `size` decrypted bytes;
+    /// AES block padding received from the device is removed.
     pub async fn read_memory_block(&mut self, address: u32, size: u32) -> Result<Vec<u8>, KMError> {
         let id = self.send_tracked(Packet::MemoryRead { address, size }).await?;
         let confirmation = self
@@ -1202,6 +1215,22 @@ mod tests {
         assert_eq!(memory_response_size(16), 16);
         assert_eq!(memory_response_size(17), 32);
         assert_eq!(memory_response_size(64), 64);
+    }
+
+    #[test]
+    fn decrypted_memory_response_is_trimmed_to_the_requested_size() {
+        let ciphertext = crate::auth::build_memory_read_payload(0x4001_0450, 12);
+        let decrypted = decrypt_memory_response(&ciphertext[..16], 12).unwrap();
+
+        assert_eq!(decrypted.len(), 12);
+        assert_eq!(&decrypted[..4], &0x4001_0450_u32.to_le_bytes());
+        assert_eq!(&decrypted[4..8], &12_u32.to_le_bytes());
+        assert_eq!(&decrypted[8..12], &u32::MAX.to_le_bytes());
+    }
+
+    #[test]
+    fn decrypted_memory_response_rejects_an_incorrect_ciphertext_size() {
+        assert!(decrypt_memory_response(&[0; 32], 12).is_err());
     }
 
     #[test]

--- a/km003c-lib/src/lib.rs
+++ b/km003c-lib/src/lib.rs
@@ -17,7 +17,9 @@ pub mod python;
 pub use python::*;
 
 // Re-export commonly used types
-pub use adcqueue::{AdcQueueData, AdcQueueSample, GraphSampleRate, sequence_elapsed};
+pub use adcqueue::{
+    AdcQueueData, AdcQueueRawData, AdcQueueSample, AdcQueueSampleRaw, GraphSampleRate, sequence_elapsed,
+};
 pub use auth::{DeviceInfo, HardwareId, StreamingAuthResult};
 pub use device::{ConnectionMode, DeviceConfig, DeviceState, KM003C, TransferType};
 pub use message::{Packet, PayloadData};

--- a/km003c-lib/src/message.rs
+++ b/km003c-lib/src/message.rs
@@ -1,5 +1,5 @@
 use crate::adc::{AdcDataRaw, AdcDataSimple};
-use crate::adcqueue::{AdcQueueData, GraphSampleRate};
+use crate::adcqueue::{AdcQueueData, AdcQueueRawData, GraphSampleRate};
 use crate::auth::{self, HardwareId, StreamingAuthResult};
 use crate::constants::*;
 use crate::error::KMError;
@@ -20,6 +20,7 @@ const PD_MONITOR_DISABLED_PARAMETER: u16 = 0;
 pub enum PayloadData {
     Adc(AdcDataSimple),
     AdcQueue(AdcQueueData),
+    AdcQueueRaw(AdcQueueRawData),
     PdStatus(PdStatus),
     PdEvents(PdEventStream),
     Unknown { attribute: Attribute, data: Vec<u8> },
@@ -98,6 +99,17 @@ impl Packet {
         }
     }
 
+    /// Get losslessly parsed AdcQueue data whose graph rate is unknown.
+    pub fn get_adc_queue_raw(&self) -> Option<&AdcQueueRawData> {
+        match self {
+            Self::DataResponse { payloads } => payloads.iter().find_map(|p| match p {
+                PayloadData::AdcQueueRaw(queue) => Some(queue),
+                _ => None,
+            }),
+            _ => None,
+        }
+    }
+
     /// Get PD status from the packet, if present
     pub fn get_pd_status(&self) -> Option<&PdStatus> {
         match self {
@@ -126,6 +138,7 @@ impl Packet {
             Self::DataResponse { payloads } => payloads.iter().any(|p| match p {
                 PayloadData::Adc(_) => attr == Attribute::Adc,
                 PayloadData::AdcQueue(_) => attr == Attribute::AdcQueue,
+                PayloadData::AdcQueueRaw(_) => attr == Attribute::AdcQueue,
                 PayloadData::PdStatus(_) | PayloadData::PdEvents(_) => attr == Attribute::PdPacket,
                 PayloadData::Unknown { attribute, .. } => *attribute == attr,
             }),
@@ -227,12 +240,11 @@ impl Packet {
                             // Parse AdcQueue data (multiple 20-byte samples)
                             // Note: Extended header size field (typically 20) indicates size per sample,
                             // not total payload size. Actual payload contains N samples.
-                            let adcqueue = if let Some(rate) = graph_rate {
-                                AdcQueueData::from_bytes_with_rate(lp.payload.as_ref(), rate)?
+                            if let Some(rate) = graph_rate {
+                                PayloadData::AdcQueue(AdcQueueData::from_bytes_with_rate(lp.payload.as_ref(), rate)?)
                             } else {
-                                AdcQueueData::from_bytes(lp.payload.as_ref())?
-                            };
-                            PayloadData::AdcQueue(adcqueue)
+                                PayloadData::AdcQueueRaw(AdcQueueRawData::from_bytes(lp.payload.as_ref())?)
+                            }
                         }
                         Attribute::PdPacket => {
                             // Determine if this is PD status or PD events
@@ -294,6 +306,15 @@ impl Packet {
                         }
                         PayloadData::AdcQueue(_) => {
                             return Err(KMError::UnsupportedSerialization { packet: "AdcQueue" });
+                        }
+                        PayloadData::AdcQueueRaw(queue) => {
+                            logical_packets.push(LogicalPacket {
+                                attribute: Attribute::AdcQueue,
+                                next: false,
+                                chunk: 0,
+                                size: 20,
+                                payload: queue.to_bytes(),
+                            });
                         }
                         PayloadData::PdEvents(_) => {
                             return Err(KMError::UnsupportedSerialization {

--- a/km003c-lib/src/pd_decode.rs
+++ b/km003c-lib/src/pd_decode.rs
@@ -113,9 +113,12 @@ impl PdSessionDecoder {
                     timestamp: event.timestamp,
                 }
             }
-            PdEventData::Disconnect(()) => DecodedPdEvent::Disconnect {
-                timestamp: event.timestamp,
-            },
+            PdEventData::Disconnect(()) => {
+                self.reset();
+                DecodedPdEvent::Disconnect {
+                    timestamp: event.timestamp,
+                }
+            }
             PdEventData::PdMessage { sop, wire_data } => self.decode_message(event.timestamp, *sop, wire_data),
         }
     }

--- a/km003c-lib/src/python.rs
+++ b/km003c-lib/src/python.rs
@@ -18,7 +18,7 @@
 //! zero-overhead Python bindings.
 
 use crate::adc::{AdcDataRaw, AdcDataSimple, SampleRate};
-use crate::adcqueue::{AdcQueueData, AdcQueueSample};
+use crate::adcqueue::{AdcQueueData, AdcQueueRawData, AdcQueueSample, AdcQueueSampleRaw};
 use crate::message::Packet;
 use crate::packet::{CtrlHeader, LogicalPacket, RawPacket};
 use crate::pd::{PdEvent, PdEventStream, PdStatus};
@@ -200,6 +200,8 @@ fn km003c_lib(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<SampleRate>()?;
     m.add_class::<AdcQueueSample>()?;
     m.add_class::<AdcQueueData>()?;
+    m.add_class::<AdcQueueSampleRaw>()?;
+    m.add_class::<AdcQueueRawData>()?;
     m.add_class::<PdStatus>()?;
     m.add_class::<PdEvent>()?;
     m.add_class::<PdEventStream>()?;

--- a/km003c-lib/tests/adc_tests.rs
+++ b/km003c-lib/tests/adc_tests.rs
@@ -59,7 +59,7 @@ fn test_adc_data_packet() {
                     assert!(adc.power.get::<watt>() > 0.0);
 
                     // Check sample rate
-                    assert_eq!(adc.sample_rate, SampleRate::Sps2);
+                    assert_eq!(adc.sample_rate, Some(SampleRate::Sps2));
 
                     println!("ADC Data: {}", adc);
                 }
@@ -173,7 +173,11 @@ fn test_adc_response_parsing_real_data() {
                     );
 
                     // Test sample rate
-                    assert_eq!(adc_data.sample_rate, SampleRate::Sps2, "Sample rate should be 2 SPS");
+                    assert_eq!(
+                        adc_data.sample_rate,
+                        Some(SampleRate::Sps2),
+                        "Sample rate should be 2 SPS"
+                    );
 
                     // Test USB data lines (should be ~0.000V)
                     assert!(

--- a/km003c-lib/tests/adcqueue_tests.rs
+++ b/km003c-lib/tests/adcqueue_tests.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use km003c_lib::{AdcQueueData, GraphSampleRate, Packet, RawPacket, sequence_elapsed};
+use km003c_lib::{AdcQueueData, AdcQueueRawData, GraphSampleRate, Packet, RawPacket, sequence_elapsed};
 use uom::si::electric_current::ampere;
 use uom::si::electric_potential::volt;
 use uom::si::time::millisecond;
@@ -8,7 +8,7 @@ use uom::si::time::millisecond;
 fn test_adcqueue_parsing() {
     // Real AdcQueue packet from pd_adcqueue_new.11 (modern firmware)
     // Main header (4) + Extended header (4) + 2 samples (2×20=40) = 48 bytes
-    // The 500-tick sequence step identifies 2 SPS and its 0.1mV scale.
+    // This capture was recorded while graph mode was configured for 2 SPS.
     let hex = "413e0202020002050de80800d5c38c00598ce8ffdc401f015b17581701ea0800\
                0bac8c000255e9ff92401e0158175417";
 
@@ -23,7 +23,7 @@ fn test_adcqueue_parsing() {
     assert_eq!(u16::from(logical_packets[0].attribute), 2); // AdcQueue
 
     // Parse to high-level packet
-    let packet = Packet::try_from(raw_packet).unwrap();
+    let packet = Packet::from_raw_with_graph_rate(raw_packet, GraphSampleRate::Sps2).unwrap();
 
     match packet {
         Packet::DataResponse { payloads } => {
@@ -37,6 +37,7 @@ fn test_adcqueue_parsing() {
                     // Check first sample (modern firmware with all fields)
                     let sample0 = &queue.samples[0];
                     assert_eq!(sample0.sequence, 59405);
+                    assert_eq!(sample0.marker, 8);
                     assert!((sample0.vbus.get::<volt>() - 9.225).abs() < 0.01); // 9225173 µV
                     assert!((sample0.ibus.get::<ampere>() + 1.537).abs() < 0.01); // -1536935 µA
                     assert!((sample0.cc1.get::<volt>() - 1.660).abs() < 0.01); // 16604×0.1mV = 1.66V
@@ -79,7 +80,7 @@ fn test_adcqueue_with_following_pd_status() {
                af3f0600b0ec300170cd1800ee01c606c500ba0010000003\
                b43f0600074e0e08ef01c606";
     let raw_packet = RawPacket::try_from(Bytes::from(hex::decode(hex).unwrap())).unwrap();
-    let packet = Packet::try_from(raw_packet).unwrap();
+    let packet = Packet::from_raw_with_graph_rate(raw_packet, GraphSampleRate::Sps1000).unwrap();
 
     assert_eq!(packet.get_adc_queue().unwrap().samples.len(), 2);
     assert!(packet.get_pd_status().is_some());
@@ -92,7 +93,7 @@ fn test_adcqueue_fast_rate_auxiliary_voltage_scale() {
     // 1mV units. The simultaneously captured ADC values provide ground truth.
     let hex = "414702050180000b30f88b00ba07ecff1fee8b00cee7ebff25ee8b00d9f0ebff3d0fd840110146174417957e00801a005302520202000205d75a09006ff68b00df02ecff7c061c0052024f02eb5a0900bdf68b00d702ecff7a061a0051025002ff5a09006df78b003d05ecff79061a0059025102135b090094f78b00be06ecff7b061b0054024e02275b090030f88b00ba07ecff7a061a0051025002";
     let raw_packet = RawPacket::try_from(Bytes::from(hex::decode(hex).unwrap())).unwrap();
-    let packet = Packet::try_from(raw_packet).unwrap();
+    let packet = Packet::from_raw_with_graph_rate(raw_packet, GraphSampleRate::Sps50).unwrap();
 
     let adc = packet.get_adc().unwrap();
     let queue = packet.get_adc_queue().unwrap();
@@ -130,10 +131,45 @@ fn test_adcqueue_sequence_check() {
     raw_bytes[20..22].copy_from_slice(&50u16.to_le_bytes());
     raw_bytes[22..24].copy_from_slice(&60u16.to_le_bytes());
 
-    let queue = AdcQueueData::from_bytes(&raw_bytes).unwrap();
+    let queue = AdcQueueRawData::from_bytes(&raw_bytes).unwrap();
     assert!(queue.has_dropped_samples(GraphSampleRate::Sps50));
 
     println!("✅ Dropped sample detection works");
+}
+
+#[test]
+fn context_free_adcqueue_parsing_is_lossless_and_does_not_guess_a_rate() {
+    let hex = "413e0202020002050de80800d5c38c00598ce8ffdc401f015b17581701ea0800\
+               0bac8c000255e9ff92401e0158175417";
+    let bytes = Bytes::from(hex::decode(hex).unwrap());
+    let raw_packet = RawPacket::try_from(bytes.clone()).unwrap();
+    let packet = Packet::try_from(raw_packet).unwrap();
+
+    assert!(packet.get_adc_queue().is_none());
+    let queue = packet.get_adc_queue_raw().unwrap();
+    assert_eq!(queue.samples[0].marker, 8);
+    assert_eq!(queue.samples[0].cc1_raw, 16_604);
+
+    let serialized = packet.to_raw_packet(0x3e).unwrap();
+    let serialized_payload = &serialized.logical_packets().unwrap()[0].payload;
+    assert_eq!(serialized_payload, &bytes[8..]);
+}
+
+#[test]
+fn context_free_single_sample_requires_an_explicit_rate_for_voltage_conversion() {
+    let mut raw_bytes = vec![0_u8; 20];
+    raw_bytes[12..14].copy_from_slice(&1_632_u16.to_le_bytes());
+
+    let raw = AdcQueueRawData::from_bytes(&raw_bytes).unwrap();
+    assert_eq!(raw.samples[0].cc1_raw, 1_632);
+    assert!((raw.decode(GraphSampleRate::Sps2).samples[0].cc1.get::<volt>() - 0.1632).abs() < 1e-12);
+    assert!((raw.decode(GraphSampleRate::Sps50).samples[0].cc1.get::<volt>() - 1.632).abs() < 1e-12);
+}
+
+#[test]
+fn adcqueue_rejects_trailing_partial_samples() {
+    let error = AdcQueueRawData::from_bytes(&[0_u8; 21]).unwrap_err();
+    assert!(error.to_string().contains("multiple of 20"));
 }
 
 #[test]

--- a/km003c-lib/tests/pd_tests.rs
+++ b/km003c-lib/tests/pd_tests.rs
@@ -161,7 +161,7 @@ fn semantically_decodes_recorded_pd_negotiation_with_source_state() {
 
 #[cfg(feature = "usbpd")]
 #[test]
-fn connection_event_resets_semantic_decoder_state() {
+fn connection_events_reset_semantic_decoder_state() {
     let stream = parse_pd_events(
         "41a90205100000168bfa1200de130000750602009f80fa120000a1632c9101082cd102002cc103002cb10400454106003c21dcc08781fa12000041028b85fa1200008210dc7003238786fa1200002101878afa120000a305878afa1200004104",
     );
@@ -174,6 +174,18 @@ fn connection_event_resets_semantic_decoder_state() {
         data: PdEventData::Connect(()),
     };
     assert!(matches!(decoder.decode_event(&connect), DecodedPdEvent::Connect { .. }));
+    assert!(decoder.source_capabilities().is_none());
+
+    decoder.decode_event(&stream.events[0]);
+    assert!(decoder.source_capabilities().is_some());
+    let disconnect = PdEvent {
+        timestamp: uom::si::f64::Time::new::<millisecond>(1_250_001.0),
+        data: PdEventData::Disconnect(()),
+    };
+    assert!(matches!(
+        decoder.decode_event(&disconnect),
+        DecodedPdEvent::Disconnect { .. }
+    ));
     assert!(decoder.source_capabilities().is_none());
 }
 

--- a/km003c-lib/tests/serialization.rs
+++ b/km003c-lib/tests/serialization.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use common::*;
-use km003c_lib::AdcQueueData;
+use km003c_lib::{AdcQueueData, GraphSampleRate};
 
 #[test]
 fn test_rawpacket_to_bytes_ctrl() {
@@ -59,7 +59,10 @@ fn auth_requests_use_their_special_wire_headers() {
 #[test]
 fn test_unsupported_semantic_payload_is_not_silently_dropped() {
     let packet = Packet::DataResponse {
-        payloads: vec![PayloadData::AdcQueue(AdcQueueData { samples: Vec::new() })],
+        payloads: vec![PayloadData::AdcQueue(AdcQueueData {
+            rate: GraphSampleRate::Sps50,
+            samples: Vec::new(),
+        })],
     };
 
     assert!(matches!(

--- a/km003c-lib/tests/serialization.rs
+++ b/km003c-lib/tests/serialization.rs
@@ -79,8 +79,26 @@ fn semantic_adc_response_uses_recorded_header_encoding() {
     let serialized = Bytes::from(packet.to_raw_packet(0).unwrap());
 
     assert_eq!(&serialized[..8], &recorded[..8]);
+    assert_eq!(
+        serialized, recorded,
+        "semantic ADC parsing must preserve every wire field"
+    );
     assert_eq!(serialized[0], 0x41, "PutData does not set the reserved bit");
     assert_eq!(&serialized[2..4], &[0x80, 0x02], "recorded ADC obj_count is 10 words");
+}
+
+#[test]
+fn unknown_adc_sample_rate_is_preserved_without_a_fallback() {
+    let mut recorded = REAL_ADC_RESPONSE.to_vec();
+    recorded[8 + 36] = 0xfe;
+
+    let packet = Packet::try_from(RawPacket::try_from(Bytes::from(recorded.clone())).unwrap()).unwrap();
+    let adc = packet.get_adc().unwrap();
+    assert_eq!(adc.sample_rate, None);
+    assert_eq!(adc.sample_rate_raw, 0xfe);
+
+    let serialized = Bytes::from(packet.to_raw_packet(0).unwrap());
+    assert_eq!(serialized.as_ref(), recorded);
 }
 
 #[test]

--- a/python/km003c/km003c_lib.pyi
+++ b/python/km003c/km003c_lib.pyi
@@ -54,6 +54,7 @@ class AdcData:
 
 class AdcQueueSample:
     sequence: int
+    marker: int
     vbus_v: float
     ibus_a: float
     power_w: float
@@ -65,7 +66,25 @@ class AdcQueueSample:
     def __str__(self) -> str: ...
 
 class AdcQueueData:
+    rate_index: int
     samples: List[AdcQueueSample]
+    def sequence_range(self) -> Optional[Tuple[int, int]]: ...
+    def has_dropped_samples(self) -> bool: ...
+    def __repr__(self) -> str: ...
+    def __str__(self) -> str: ...
+
+class AdcQueueSampleRaw:
+    sequence: int
+    marker: int
+    vbus_uv: int
+    ibus_ua: int
+    cc1_raw: int
+    cc2_raw: int
+    vdp_raw: int
+    vdm_raw: int
+
+class AdcQueueRawData:
+    samples: List[AdcQueueSampleRaw]
     def sequence_range(self) -> Optional[Tuple[int, int]]: ...
     def has_dropped_samples(self, rate_index: int) -> bool: ...
     def __repr__(self) -> str: ...

--- a/python/km003c/km003c_lib.pyi
+++ b/python/km003c/km003c_lib.pyi
@@ -48,7 +48,11 @@ class AdcData:
     cc2_v: float
     cc2_avg_v: float
     internal_vdd_v: float
-    sample_rate: SampleRate
+    sample_rate: Optional[SampleRate]
+    sample_rate_raw: int
+    vendor_flags: int
+    vbus_uncalibrated_average_raw: int
+    ibus_uncalibrated_average_raw: int
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
 

--- a/test_bindings.py
+++ b/test_bindings.py
@@ -43,8 +43,11 @@ def test_adcqueue_helpers_use_rate_index():
     )
     queue = km003c.parse_packet(raw)["DataResponse"]["payloads"][0]
 
+    assert repr(queue).startswith("AdcQueueRawData")
     assert queue.sequence_range() == (59405, 59905)
     assert not queue.has_dropped_samples(km003c.RATE_2_SPS)
+    assert queue.samples[0].marker == 8
+    assert queue.samples[0].cc1_raw == 16604
 
 
 def test_raw_adc_parsing():


### PR DESCRIPTION
## What changed

- parse context-free AdcQueue payloads losslessly without guessing a sample rate
- preserve every ADC wire field and represent unknown sample-rate indices explicitly
- trim decrypted MemoryRead results to the requested byte count
- reset semantic USB PD state on both connect and disconnect events
- reject StartGraph locally unless StreamingAuth enabled AdcQueue
- fix memory_scan to use correlated high-level memory reads and add safe clap options
- explicitly enable and disable the PD monitor in test_usbpd
- update Rust tests, Python bindings, and type stubs for the new APIs

## Root causes

The old context-free AdcQueue parser inferred the rate from sequence steps and silently fell back to 2 SPS, which could produce incorrect auxiliary voltages. ADC semantic round-trips discarded uncalibrated averages and vendor flags and also replaced unknown rate indices with 2 SPS. Memory reads exposed AES padding, the PD decoder retained state after disconnect, and StartGraph could be sent even after streaming authentication was denied.

Hardware validation also exposed two CLI bugs: memory_scan bypassed the correlated MemoryRead API and misparsed confirmations or ciphertext as unrelated framed packets, while test_usbpd did not manage the PD monitor lifecycle.

This intentionally includes API changes suitable for the upcoming 0.2.0 release: context-free AdcQueue data is returned as AdcQueueRawData, typed AdcQueueData stores its rate, and AdcData sample_rate is optional when the wire index is unknown.

## Validation

Automated:

- just ci
- all workspace tests and doctests pass
- clippy passes with warnings denied
- documentation and crate package verification pass
- Python extension builds and all 5 binding tests pass

KM003C hardware, firmware 1.9.9:

- vendor initialization and StreamingAuth succeeded repeatedly with auth level 1
- ADC: 8.986 V, -0.040 A, CC1 1.632 V, CC2 0 V, D+ 0.582 V, D- 0.003 V
- MemoryRead returned exact requested lengths for 1, 12, 16, 17, and 64 bytes
- Hardware ID read returned exactly 12 bytes
- AdcQueue delivered exactly 2.0, 10.0, 50.0, and 1000.0 SPS with zero missing samples
- single-sample 2 SPS AdcQueue responses decoded correctly with the explicitly configured rate
- physical disconnect/reconnect produced fresh Source Capabilities followed by a correctly stateful Request, Accept, and PS_RDY sequence
- PD monitor enable and disable commands were accepted