### PR TITLE
Add typed offline log downloads and fix multi-log selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Shared stateful USB PD decoding, including chunked EPR messages.
-- Typed `LogMetadata` attribute support in the protocol header layer.
+- Typed offline-log catalogs and samples, including high-level encrypted
+  downloads and final-accumulator validation.
+- `offline-log` CLI with metadata inspection and CSV/JSON export.
 - Explicit-rate AdcQueue decoding in Python through
   `AdcQueueRawData.decode()` and `parse_packet_with_graph_rate()`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,6 +1805,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,7 +1911,9 @@ name = "km003c-cli"
 version = "0.2.0"
 dependencies = [
  "clap",
+ "hex",
  "km003c-lib",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3217,6 +3225,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.0",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -4928,6 +4949,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zune-core"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Core library providing:
 - Device communication and automatic initialization
 - Streaming authentication (required for AdcQueue)
 - ADC and AdcQueue data parsing
+- Offline recording catalog and encrypted log downloads
 - USB PD event parsing
 - Optional stateful USB PD semantic decoding through the `usbpd` feature
 
@@ -60,6 +61,7 @@ Command-line tools:
 - `adc_simple` - Single-shot ADC readings with device info
 - `adc_queue_simple` - AdcQueue streaming demo
 - `test_usbpd` - USB PD negotiation capture
+- `offline-log` - List and export stored recordings as CSV or JSON
 
 ### `km003c-egui`
 GUI application featuring:
@@ -119,6 +121,13 @@ cargo run --bin adc_queue_simple -- --rate 50 --duration 10
 
 ```bash
 cargo run --bin test_usbpd
+```
+
+#### Offline Recordings
+
+```bash
+cargo run --bin offline-log -- metadata
+cargo run --bin offline-log -- download --index 0 --format csv
 ```
 
 #### GUI Application
@@ -181,6 +190,18 @@ let plaintext_blocks = km003c_lib::auth::decrypt_memory_read_response(&ciphertex
 
 The offline helper returns complete decrypted AES blocks because a capture does
 not itself carry the originally requested byte count.
+
+Stored recordings have a higher-level API. Metadata requests return every
+catalog entry; each entry carries the memory offset needed to download that
+specific log:
+
+```rust,no_run
+let catalog = device.request_log_metadata().await?;
+if let Some(metadata) = catalog.into_iter().next() {
+    let log = device.download_offline_log(metadata).await?;
+    println!("downloaded {} samples", log.samples.len());
+}
+```
 
 ### Python bindings
 

--- a/km003c-cli/Cargo.toml
+++ b/km003c-cli/Cargo.toml
@@ -9,9 +9,15 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[[bin]]
+name = "offline-log"
+path = "src/bin/offline_log.rs"
+
 [dependencies]
 km003c-lib = { workspace = true, features = ["usbpd"] }
 tokio.workspace = true
 clap = { version = "4.6.2", features = ["derive"] }
+hex = "0.4"
+serde_json = "1.0.149"
 tracing-subscriber.workspace = true
 tracing.workspace = true

--- a/km003c-cli/src/bin/offline_log.rs
+++ b/km003c-cli/src/bin/offline_log.rs
@@ -47,6 +47,10 @@ enum Command {
     },
     /// Download all samples and write them to a file.
     Download {
+        /// Zero-based index shown by the metadata command.
+        #[arg(short, long, default_value_t = 0)]
+        index: usize,
+
         /// Output format.
         #[arg(short, long, value_enum, default_value_t = OutputFormat::Csv)]
         format: OutputFormat,
@@ -90,17 +94,25 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     match args.command {
         Command::Metadata { json } => {
-            let Some(metadata) = device.request_log_metadata().await? else {
+            let metadata = device.request_log_metadata().await?;
+            if metadata.is_empty() {
                 println!("No offline log is selected on the device.");
                 return Ok(());
-            };
-            print_metadata(&metadata, json)?;
+            }
+            print_metadata_list(&metadata, json)?;
         }
-        Command::Download { format, output } => {
-            let Some(metadata) = device.request_log_metadata().await? else {
+        Command::Download { index, format, output } => {
+            let metadata = device.request_log_metadata().await?;
+            if metadata.is_empty() {
                 println!("No offline log is selected on the device.");
                 return Ok(());
-            };
+            }
+            let metadata = metadata.get(index).cloned().ok_or_else(|| {
+                format!(
+                    "offline log index {index} is out of range; device reported {} logs",
+                    metadata.len()
+                )
+            })?;
             let path = output.unwrap_or_else(|| default_output_path(&metadata, format));
             let log = device.download_offline_log(metadata).await?;
             write_log(&path, format, &log)?;
@@ -121,7 +133,11 @@ fn metadata_json(metadata: &LogMetadata) -> serde_json::Value {
         "recorded_duration_seconds": metadata.recorded_duration.get::<second>(),
         "calculated_duration_seconds": metadata.calculated_duration().get::<second>(),
         "unknown_0x10": metadata.unknown_0x10,
-        "opaque_tail": hex::encode(metadata.opaque_tail),
+        "final_charge_uah": metadata.final_charge_raw_uah(),
+        "final_energy_uwh": metadata.final_energy_raw_uwh(),
+        "data_offset": metadata.data_offset,
+        "data_address": metadata.data_address().ok(),
+        "reserved_tail": hex::encode(metadata.reserved_tail),
     })
 }
 
@@ -140,7 +156,27 @@ fn print_metadata(metadata: &LogMetadata, as_json: bool) -> Result<(), Box<dyn E
         println!("Data size:           {} bytes", metadata.data_size());
         println!("Flags:               0x{:04x}", metadata.flags);
         println!("Unknown field 0x10:  0x{:04x}", metadata.unknown_0x10);
-        println!("Opaque tail:         {}", hex::encode(metadata.opaque_tail));
+        println!("Final charge:        {} µAh", metadata.final_charge_raw_uah());
+        println!("Final energy:        {} µWh", metadata.final_energy_raw_uwh());
+        println!("Data offset:         0x{:08x}", metadata.data_offset);
+        println!("Data address:        0x{:08x}", metadata.data_address()?);
+        println!("Reserved tail:       {}", hex::encode(metadata.reserved_tail));
+    }
+    Ok(())
+}
+
+fn print_metadata_list(metadata: &[LogMetadata], as_json: bool) -> Result<(), Box<dyn Error>> {
+    if as_json {
+        let entries = metadata.iter().map(metadata_json).collect::<Vec<_>>();
+        println!("{}", serde_json::to_string_pretty(&entries)?);
+    } else {
+        for (index, entry) in metadata.iter().enumerate() {
+            if index > 0 {
+                println!();
+            }
+            println!("Offline log #{index}");
+            print_metadata(entry, false)?;
+        }
     }
     Ok(())
 }
@@ -225,6 +261,8 @@ fn write_json(mut writer: impl Write, log: &OfflineLog) -> Result<(), Box<dyn Er
 #[cfg(test)]
 mod tests {
     use km003c_lib::LogMetadata;
+    use km003c_lib::uom::si::electric_charge::microampere_hour;
+    use km003c_lib::uom::si::energy::microwatt_hour;
     use km003c_lib::uom::si::f64::Time;
 
     use super::*;
@@ -239,7 +277,10 @@ mod tests {
             interval: Time::new::<millisecond>(1_000.0),
             flags: 0,
             recorded_duration: Time::new::<second>(0.0),
-            opaque_tail: [0; 20],
+            final_charge: km003c_lib::uom::si::f64::ElectricCharge::new::<microampere_hour>(0.0),
+            final_energy: km003c_lib::uom::si::f64::Energy::new::<microwatt_hour>(0.0),
+            data_offset: 0,
+            reserved_tail: [0; 8],
         }
     }
 
@@ -263,6 +304,8 @@ mod tests {
     fn exports_exact_raw_sample_values() {
         let mut metadata = metadata(b"A01.d");
         metadata.sample_count = 1;
+        metadata.final_charge = km003c_lib::uom::si::f64::ElectricCharge::new::<microampere_hour>(-5_290.0);
+        metadata.final_energy = km003c_lib::uom::si::f64::Energy::new::<microwatt_hour>(-26_439.0);
         let bytes = hex::decode("81494c0021f0e2ff56ebffffb998ffff").unwrap();
         let log = OfflineLog::from_bytes(metadata, &bytes).unwrap();
 

--- a/km003c-cli/src/bin/offline_log.rs
+++ b/km003c-cli/src/bin/offline_log.rs
@@ -96,7 +96,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Command::Metadata { json } => {
             let metadata = device.request_log_metadata().await?;
             if metadata.is_empty() {
-                println!("No offline log is selected on the device.");
+                println!("No offline logs are stored on the device.");
                 return Ok(());
             }
             print_metadata_list(&metadata, json)?;
@@ -104,7 +104,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Command::Download { index, format, output } => {
             let metadata = device.request_log_metadata().await?;
             if metadata.is_empty() {
-                println!("No offline log is selected on the device.");
+                println!("No offline logs are stored on the device.");
                 return Ok(());
             }
             let metadata = metadata.get(index).cloned().ok_or_else(|| {

--- a/km003c-cli/src/bin/offline_log.rs
+++ b/km003c-cli/src/bin/offline_log.rs
@@ -1,0 +1,283 @@
+use std::error::Error;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use clap::{Parser, Subcommand, ValueEnum};
+use km003c_lib::uom::si::electric_charge::milliampere_hour;
+use km003c_lib::uom::si::electric_current::ampere;
+use km003c_lib::uom::si::electric_potential::volt;
+use km003c_lib::uom::si::energy::milliwatt_hour;
+use km003c_lib::uom::si::power::watt;
+use km003c_lib::uom::si::time::{millisecond, second};
+use km003c_lib::{DeviceConfig, KM003C, LogMetadata, OfflineLog};
+use serde_json::json;
+
+/// Inspect or download the selected offline recording from a POWER-Z KM003C.
+#[derive(Debug, Parser)]
+#[command(
+    version,
+    about = "Inspect or download offline recordings from a POWER-Z KM003C",
+    long_about = None
+)]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+
+    /// Show protocol and USB debug logs.
+    #[arg(short, long, global = true)]
+    verbose: bool,
+
+    /// Skip USB reset (defaults to true on macOS for compatibility).
+    #[arg(long, default_value_t = cfg!(target_os = "macos"), global = true)]
+    no_reset: bool,
+
+    /// Force USB reset even on macOS (overrides --no-reset).
+    #[arg(long, global = true)]
+    reset: bool,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Display metadata without downloading sample data.
+    Metadata {
+        /// Print machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Download all samples and write them to a file.
+    Download {
+        /// Output format.
+        #[arg(short, long, value_enum, default_value_t = OutputFormat::Csv)]
+        format: OutputFormat,
+
+        /// Output path. Defaults to <device-filename>.csv or .json.
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum OutputFormat {
+    Csv,
+    Json,
+}
+
+impl OutputFormat {
+    const fn extension(self) -> &'static str {
+        match self {
+            Self::Csv => "csv",
+            Self::Json => "json",
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
+    let log_level = if args.verbose {
+        tracing::Level::DEBUG
+    } else {
+        tracing::Level::WARN
+    };
+    tracing_subscriber::fmt().with_max_level(log_level).init();
+
+    let mut config = DeviceConfig::vendor();
+    if args.no_reset && !args.reset {
+        config = config.skip_reset();
+    }
+    let mut device = KM003C::new(config).await?;
+
+    match args.command {
+        Command::Metadata { json } => {
+            let Some(metadata) = device.request_log_metadata().await? else {
+                println!("No offline log is selected on the device.");
+                return Ok(());
+            };
+            print_metadata(&metadata, json)?;
+        }
+        Command::Download { format, output } => {
+            let Some(metadata) = device.request_log_metadata().await? else {
+                println!("No offline log is selected on the device.");
+                return Ok(());
+            };
+            let path = output.unwrap_or_else(|| default_output_path(&metadata, format));
+            let log = device.download_offline_log(metadata).await?;
+            write_log(&path, format, &log)?;
+            println!("Wrote {} samples to {}", log.samples.len(), path.display());
+        }
+    }
+
+    Ok(())
+}
+
+fn metadata_json(metadata: &LogMetadata) -> serde_json::Value {
+    json!({
+        "filename": metadata.filename_lossy(),
+        "filename_raw": metadata.filename_raw,
+        "sample_count": metadata.sample_count,
+        "interval_ms": metadata.interval.get::<millisecond>(),
+        "flags": metadata.flags,
+        "recorded_duration_seconds": metadata.recorded_duration.get::<second>(),
+        "calculated_duration_seconds": metadata.calculated_duration().get::<second>(),
+        "unknown_0x10": metadata.unknown_0x10,
+        "opaque_tail": hex::encode(metadata.opaque_tail),
+    })
+}
+
+fn print_metadata(metadata: &LogMetadata, as_json: bool) -> Result<(), Box<dyn Error>> {
+    if as_json {
+        println!("{}", serde_json::to_string_pretty(&metadata_json(metadata))?);
+    } else {
+        println!("Filename:            {}", metadata.filename_lossy());
+        println!("Samples:             {}", metadata.sample_count);
+        println!("Interval:            {} ms", metadata.interval.get::<millisecond>());
+        println!("Recorded duration:   {} s", metadata.recorded_duration.get::<second>());
+        println!(
+            "Calculated duration: {} s",
+            metadata.calculated_duration().get::<second>()
+        );
+        println!("Data size:           {} bytes", metadata.data_size());
+        println!("Flags:               0x{:04x}", metadata.flags);
+        println!("Unknown field 0x10:  0x{:04x}", metadata.unknown_0x10);
+        println!("Opaque tail:         {}", hex::encode(metadata.opaque_tail));
+    }
+    Ok(())
+}
+
+fn default_output_path(metadata: &LogMetadata, format: OutputFormat) -> PathBuf {
+    let device_filename = metadata.filename_lossy();
+    let filename = Path::new(device_filename.as_ref())
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("offline-log");
+    PathBuf::from(format!("{filename}.{}", format.extension()))
+}
+
+fn write_log(path: &Path, format: OutputFormat, log: &OfflineLog) -> Result<(), Box<dyn Error>> {
+    let file = File::create(path)?;
+    let mut writer = BufWriter::new(file);
+    match format {
+        OutputFormat::Csv => write_csv(&mut writer, log)?,
+        OutputFormat::Json => write_json(&mut writer, log)?,
+    }
+    writer.flush()?;
+    Ok(())
+}
+
+fn write_csv(mut writer: impl Write, log: &OfflineLog) -> Result<(), std::io::Error> {
+    writeln!(
+        writer,
+        "index,elapsed_seconds,voltage_uv,current_ua,power_w,charge_uah,energy_uwh,voltage_v,current_a,charge_mah,energy_mwh"
+    )?;
+    let interval_seconds = log.metadata.interval.get::<second>();
+    for (index, sample) in log.samples.iter().enumerate() {
+        let raw = sample.raw();
+        writeln!(
+            writer,
+            "{index},{},{},{},{},{},{},{},{},{},{}",
+            index as f64 * interval_seconds,
+            raw.voltage_uv,
+            raw.current_ua,
+            sample.power.get::<watt>(),
+            raw.charge_uah,
+            raw.energy_uwh,
+            sample.voltage.get::<volt>(),
+            sample.current.get::<ampere>(),
+            sample.charge.get::<milliampere_hour>(),
+            sample.energy.get::<milliwatt_hour>(),
+        )?;
+    }
+    Ok(())
+}
+
+fn write_json(mut writer: impl Write, log: &OfflineLog) -> Result<(), Box<dyn Error>> {
+    let interval_seconds = log.metadata.interval.get::<second>();
+    let samples = log
+        .samples
+        .iter()
+        .enumerate()
+        .map(|(index, sample)| {
+            let raw = sample.raw();
+            json!({
+                "index": index,
+                "elapsed_seconds": index as f64 * interval_seconds,
+                "voltage_uv": raw.voltage_uv,
+                "current_ua": raw.current_ua,
+                "power_w": sample.power.get::<watt>(),
+                "charge_uah": raw.charge_uah,
+                "energy_uwh": raw.energy_uwh,
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::to_writer_pretty(
+        &mut writer,
+        &json!({
+            "metadata": metadata_json(&log.metadata),
+            "samples": samples,
+        }),
+    )?;
+    writeln!(writer)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use km003c_lib::LogMetadata;
+    use km003c_lib::uom::si::f64::Time;
+
+    use super::*;
+
+    fn metadata(filename: &[u8]) -> LogMetadata {
+        let mut filename_raw = [0; 16];
+        filename_raw[..filename.len()].copy_from_slice(filename);
+        LogMetadata {
+            filename_raw,
+            unknown_0x10: 0,
+            sample_count: 0,
+            interval: Time::new::<millisecond>(1_000.0),
+            flags: 0,
+            recorded_duration: Time::new::<second>(0.0),
+            opaque_tail: [0; 20],
+        }
+    }
+
+    #[test]
+    fn default_path_preserves_the_device_extension() {
+        assert_eq!(
+            default_output_path(&metadata(b"A01.d"), OutputFormat::Csv),
+            PathBuf::from("A01.d.csv")
+        );
+    }
+
+    #[test]
+    fn default_path_drops_device_directories() {
+        assert_eq!(
+            default_output_path(&metadata(b"../A01.d"), OutputFormat::Json),
+            PathBuf::from("A01.d.json")
+        );
+    }
+
+    #[test]
+    fn exports_exact_raw_sample_values() {
+        let mut metadata = metadata(b"A01.d");
+        metadata.sample_count = 1;
+        let bytes = hex::decode("81494c0021f0e2ff56ebffffb998ffff").unwrap();
+        let log = OfflineLog::from_bytes(metadata, &bytes).unwrap();
+
+        let mut csv = Vec::new();
+        write_csv(&mut csv, &log).unwrap();
+        let csv = String::from_utf8(csv).unwrap();
+        assert!(csv.contains("0,0,4999553,-1904607,"));
+        assert!(csv.contains(",-5290,-26439,"));
+
+        let mut json = Vec::new();
+        write_json(&mut json, &log).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&json).unwrap();
+        assert_eq!(value["samples"][0]["voltage_uv"], 4_999_553);
+        assert_eq!(value["samples"][0]["current_ua"], -1_904_607);
+        assert_eq!(value["samples"][0]["charge_uah"], -5_290);
+        assert_eq!(value["samples"][0]["energy_uwh"], -26_439);
+    }
+}

--- a/km003c-cli/src/bin/offline_log.rs
+++ b/km003c-cli/src/bin/offline_log.rs
@@ -55,7 +55,7 @@ enum Command {
         #[arg(short, long, value_enum, default_value_t = OutputFormat::Csv)]
         format: OutputFormat,
 
-        /// Output path. Defaults to <device-filename>.csv or .json.
+        /// Output path. Defaults to `<device-filename>.csv` or `.json`.
         #[arg(short, long)]
         output: Option<PathBuf>,
     },

--- a/km003c-lib/README.md
+++ b/km003c-lib/README.md
@@ -8,6 +8,10 @@ streaming at 2/10/50/1000 SPS, USB Power Delivery event capture, device
 information, and recorded-packet parsing. Physical measurements use
 [`uom`](https://docs.rs/uom) quantities throughout the Rust API.
 
+Offline recordings are exposed as a catalog of typed `LogMetadata` entries.
+`KM003C::download_offline_log()` selects the correct flash offset, validates
+the final charge and energy accumulators, and returns typed `uom` samples.
+
 Enable the optional `usbpd` feature to turn captured PD wire frames into typed
 USB PD messages. `PdSessionDecoder` retains Source Capabilities state for
 subsequent Request messages and reassembles chunked EPR Source Capabilities.

--- a/km003c-lib/src/device.rs
+++ b/km003c-lib/src/device.rs
@@ -47,7 +47,7 @@ use crate::adcqueue::GraphSampleRate;
 use crate::auth::{DeviceInfo, HardwareId};
 use crate::error::KMError;
 use crate::message::Packet;
-use crate::offline::{LogMetadata, LogMetadataResponse, OFFLINE_LOG_ADDRESS, OfflineLog};
+use crate::offline::{LogMetadata, LogMetadataResponse, OfflineLog};
 use crate::packet::{Attribute, AttributeSet, PacketType, RawPacket};
 use crate::pd::{PdEventStream, PdStatus};
 use bytes::Bytes;
@@ -833,12 +833,12 @@ impl KM003C {
 
     /// Request metadata for the offline log currently selected on the device.
     ///
-    /// Returns `None` when the device reports that no offline log is available.
-    pub async fn request_log_metadata(&mut self) -> Result<Option<LogMetadata>, KMError> {
+    /// Returns an empty vector when no offline log is available.
+    pub async fn request_log_metadata(&mut self) -> Result<Vec<LogMetadata>, KMError> {
         let packet = self.request_data(AttributeSet::single(Attribute::LogMetadata)).await?;
         match packet.get_log_metadata() {
-            Some(LogMetadataResponse::Empty) => Ok(None),
-            Some(LogMetadataResponse::Available(metadata)) => Ok(Some(metadata.clone())),
+            Some(LogMetadataResponse::Empty) => Ok(Vec::new()),
+            Some(LogMetadataResponse::Available(metadata)) => Ok(metadata.clone()),
             None => Err(KMError::Protocol("No LogMetadata data in response".to_string())),
         }
     }
@@ -846,19 +846,9 @@ impl KM003C {
     /// Download the offline samples described by previously requested metadata.
     pub async fn download_offline_log(&mut self, metadata: LogMetadata) -> Result<OfflineLog, KMError> {
         let data = self
-            .read_memory_block(OFFLINE_LOG_ADDRESS, metadata.data_size())
+            .read_memory_block(metadata.data_address()?, metadata.data_size())
             .await?;
         OfflineLog::from_bytes(metadata, &data)
-    }
-
-    /// Request metadata and download the selected offline log.
-    ///
-    /// Returns `None` when no offline log is available.
-    pub async fn read_offline_log(&mut self) -> Result<Option<OfflineLog>, KMError> {
-        let Some(metadata) = self.request_log_metadata().await? else {
-            return Ok(None);
-        };
-        self.download_offline_log(metadata).await.map(Some)
     }
 
     /// Request PD data (returns full packet as it can contain PdStatus OR PdEventStream)

--- a/km003c-lib/src/device.rs
+++ b/km003c-lib/src/device.rs
@@ -47,6 +47,7 @@ use crate::adcqueue::GraphSampleRate;
 use crate::auth::{DeviceInfo, HardwareId};
 use crate::error::KMError;
 use crate::message::Packet;
+use crate::offline::{LogMetadata, LogMetadataResponse, OFFLINE_LOG_ADDRESS, OfflineLog};
 use crate::packet::{Attribute, AttributeSet, PacketType, RawPacket};
 use crate::pd::{PdEventStream, PdStatus};
 use bytes::Bytes;
@@ -828,6 +829,36 @@ impl KM003C {
             .get_adc()
             .cloned()
             .ok_or_else(|| KMError::Protocol("No ADC data in response".to_string()))
+    }
+
+    /// Request metadata for the offline log currently selected on the device.
+    ///
+    /// Returns `None` when the device reports that no offline log is available.
+    pub async fn request_log_metadata(&mut self) -> Result<Option<LogMetadata>, KMError> {
+        let packet = self.request_data(AttributeSet::single(Attribute::LogMetadata)).await?;
+        match packet.get_log_metadata() {
+            Some(LogMetadataResponse::Empty) => Ok(None),
+            Some(LogMetadataResponse::Available(metadata)) => Ok(Some(metadata.clone())),
+            None => Err(KMError::Protocol("No LogMetadata data in response".to_string())),
+        }
+    }
+
+    /// Download the offline samples described by previously requested metadata.
+    pub async fn download_offline_log(&mut self, metadata: LogMetadata) -> Result<OfflineLog, KMError> {
+        let data = self
+            .read_memory_block(OFFLINE_LOG_ADDRESS, metadata.data_size())
+            .await?;
+        OfflineLog::from_bytes(metadata, &data)
+    }
+
+    /// Request metadata and download the selected offline log.
+    ///
+    /// Returns `None` when no offline log is available.
+    pub async fn read_offline_log(&mut self) -> Result<Option<OfflineLog>, KMError> {
+        let Some(metadata) = self.request_log_metadata().await? else {
+            return Ok(None);
+        };
+        self.download_offline_log(metadata).await.map(Some)
     }
 
     /// Request PD data (returns full packet as it can contain PdStatus OR PdEventStream)

--- a/km003c-lib/src/lib.rs
+++ b/km003c-lib/src/lib.rs
@@ -5,6 +5,7 @@ pub mod constants;
 pub mod device;
 pub mod error;
 pub mod message;
+pub mod offline;
 pub mod packet;
 pub mod pd;
 #[cfg(feature = "usbpd")]
@@ -23,6 +24,7 @@ pub use adcqueue::{
 pub use auth::{DeviceInfo, HardwareId, StreamingAuthResult};
 pub use device::{ConnectionMode, DeviceConfig, DeviceState, KM003C, TransferType};
 pub use message::{Packet, PayloadData};
+pub use offline::{LogMetadata, LogMetadataResponse, OfflineLog, OfflineLogSample, OfflineLogSampleRaw};
 pub use packet::{Attribute, AttributeSet, LogicalPacket, RawPacket};
 pub use pd::{PdEvent, PdEventData, PdEventStream, PdStatus};
 #[cfg(feature = "usbpd")]

--- a/km003c-lib/src/message.rs
+++ b/km003c-lib/src/message.rs
@@ -272,9 +272,19 @@ impl Packet {
                             if lp.payload.is_empty() {
                                 PayloadData::LogMetadata(LogMetadataResponse::Empty)
                             } else {
-                                PayloadData::LogMetadata(LogMetadataResponse::Available(LogMetadata::from_bytes(
-                                    &lp.payload,
-                                )?))
+                                if !lp.payload.len().is_multiple_of(crate::offline::LOG_METADATA_SIZE) {
+                                    return Err(KMError::InvalidPacket(format!(
+                                        "LogMetadata payload length must be a multiple of {}, got {}",
+                                        crate::offline::LOG_METADATA_SIZE,
+                                        lp.payload.len()
+                                    )));
+                                }
+                                let entries = lp
+                                    .payload
+                                    .chunks_exact(crate::offline::LOG_METADATA_SIZE)
+                                    .map(LogMetadata::from_bytes)
+                                    .collect::<Result<Vec<_>, _>>()?;
+                                PayloadData::LogMetadata(LogMetadataResponse::Available(entries))
                             }
                         }
                         _ => PayloadData::Unknown {
@@ -342,7 +352,9 @@ impl Packet {
                         PayloadData::LogMetadata(response) => {
                             let payload = match response {
                                 LogMetadataResponse::Empty => Vec::new(),
-                                LogMetadataResponse::Available(metadata) => metadata.to_bytes(),
+                                LogMetadataResponse::Available(metadata) => {
+                                    metadata.iter().flat_map(LogMetadata::to_bytes).collect()
+                                }
                             };
                             logical_packets.push(LogicalPacket {
                                 attribute: Attribute::LogMetadata,

--- a/km003c-lib/src/message.rs
+++ b/km003c-lib/src/message.rs
@@ -3,6 +3,7 @@ use crate::adcqueue::{AdcQueueData, AdcQueueRawData, GraphSampleRate};
 use crate::auth::{self, HardwareId, StreamingAuthResult};
 use crate::constants::*;
 use crate::error::KMError;
+use crate::offline::{LogMetadata, LogMetadataResponse};
 use crate::packet::{
     Attribute, AttributeSet, CtrlHeader, DataHeader, LogicalPacket, PacketType, RawPacket, StreamingAuthHeader,
 };
@@ -23,6 +24,7 @@ pub enum PayloadData {
     AdcQueueRaw(AdcQueueRawData),
     PdStatus(PdStatus),
     PdEvents(PdEventStream),
+    LogMetadata(LogMetadataResponse),
     Unknown { attribute: Attribute, data: Vec<u8> },
 }
 
@@ -127,6 +129,17 @@ impl Packet {
         }
     }
 
+    /// Get the response to a LogMetadata request, if present.
+    pub fn get_log_metadata(&self) -> Option<&LogMetadataResponse> {
+        match self {
+            Self::DataResponse { payloads } => payloads.iter().find_map(|payload| match payload {
+                PayloadData::LogMetadata(metadata) => Some(metadata),
+                _ => None,
+            }),
+            _ => None,
+        }
+    }
+
     /// Check if packet has a specific payload type
     pub fn has_payload(&self, attr: Attribute) -> bool {
         match self {
@@ -135,6 +148,7 @@ impl Packet {
                 PayloadData::AdcQueue(_) => attr == Attribute::AdcQueue,
                 PayloadData::AdcQueueRaw(_) => attr == Attribute::AdcQueue,
                 PayloadData::PdStatus(_) | PayloadData::PdEvents(_) => attr == Attribute::PdPacket,
+                PayloadData::LogMetadata(_) => attr == Attribute::LogMetadata,
                 PayloadData::Unknown { attribute, .. } => *attribute == attr,
             }),
             _ => false,
@@ -254,6 +268,15 @@ impl Packet {
                                 PayloadData::PdEvents(pd_events)
                             }
                         }
+                        Attribute::LogMetadata => {
+                            if lp.payload.is_empty() {
+                                PayloadData::LogMetadata(LogMetadataResponse::Empty)
+                            } else {
+                                PayloadData::LogMetadata(LogMetadataResponse::Available(LogMetadata::from_bytes(
+                                    &lp.payload,
+                                )?))
+                            }
+                        }
                         _ => PayloadData::Unknown {
                             attribute: lp.attribute,
                             data: lp.payload.to_vec(),
@@ -314,6 +337,19 @@ impl Packet {
                         PayloadData::PdEvents(_) => {
                             return Err(KMError::UnsupportedSerialization {
                                 packet: "PdEventStream",
+                            });
+                        }
+                        PayloadData::LogMetadata(response) => {
+                            let payload = match response {
+                                LogMetadataResponse::Empty => Vec::new(),
+                                LogMetadataResponse::Available(metadata) => metadata.to_bytes(),
+                            };
+                            logical_packets.push(LogicalPacket {
+                                attribute: Attribute::LogMetadata,
+                                next: false,
+                                chunk: 0,
+                                size: payload.len() as u16,
+                                payload,
                             });
                         }
                         PayloadData::Unknown { attribute, data } => {

--- a/km003c-lib/src/offline.rs
+++ b/km003c-lib/src/offline.rs
@@ -1,0 +1,340 @@
+use std::borrow::Cow;
+
+use uom::si::electric_charge::microampere_hour;
+use uom::si::electric_current::microampere;
+use uom::si::electric_potential::microvolt;
+use uom::si::energy::microwatt_hour;
+use uom::si::f64::{ElectricCharge, ElectricCurrent, ElectricPotential, Energy, Power, Time};
+use uom::si::time::{millisecond, second};
+use zerocopy::byteorder::little_endian::{I32, U16, U32};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use crate::error::KMError;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Device memory address containing the currently selected offline log.
+pub const OFFLINE_LOG_ADDRESS: u32 = 0x9810_0000;
+/// Size of a `LogMetadata` payload.
+pub const LOG_METADATA_SIZE: usize = 48;
+/// Size of one offline log sample.
+pub const OFFLINE_LOG_SAMPLE_SIZE: usize = 16;
+
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+struct LogMetadataWire {
+    filename: [u8; 16],
+    unknown_0x10: U16,
+    sample_count: U16,
+    interval_ms: U16,
+    flags: U16,
+    recorded_duration_seconds: U32,
+    opaque_tail: [u8; 20],
+}
+
+/// Metadata describing the offline log selected on the device.
+///
+/// Fields whose meaning has not been established are preserved verbatim and
+/// deliberately named after their wire position rather than guessed.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "python", pyo3::pyclass(skip_from_py_object))]
+pub struct LogMetadata {
+    pub filename_raw: [u8; 16],
+    pub unknown_0x10: u16,
+    pub sample_count: u16,
+    pub interval: Time,
+    pub flags: u16,
+    pub recorded_duration: Time,
+    pub opaque_tail: [u8; 20],
+}
+
+impl LogMetadata {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, KMError> {
+        if bytes.len() != LOG_METADATA_SIZE {
+            return Err(KMError::InvalidPacket(format!(
+                "LogMetadata payload must be exactly {LOG_METADATA_SIZE} bytes, got {}",
+                bytes.len()
+            )));
+        }
+
+        let wire = LogMetadataWire::ref_from_bytes(bytes)
+            .map_err(|_| KMError::InvalidPacket("Failed to parse LogMetadata".to_string()))?;
+
+        Ok(Self {
+            filename_raw: wire.filename,
+            unknown_0x10: wire.unknown_0x10.get(),
+            sample_count: wire.sample_count.get(),
+            interval: Time::new::<millisecond>(f64::from(wire.interval_ms.get())),
+            flags: wire.flags.get(),
+            recorded_duration: Time::new::<second>(f64::from(wire.recorded_duration_seconds.get())),
+            opaque_tail: wire.opaque_tail,
+        })
+    }
+
+    /// Filename bytes up to the first NUL terminator.
+    pub fn filename_bytes(&self) -> &[u8] {
+        let length = self
+            .filename_raw
+            .iter()
+            .position(|byte| *byte == 0)
+            .unwrap_or(self.filename_raw.len());
+        &self.filename_raw[..length]
+    }
+
+    pub fn filename(&self) -> Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(self.filename_bytes())
+    }
+
+    pub fn filename_lossy(&self) -> Cow<'_, str> {
+        String::from_utf8_lossy(self.filename_bytes())
+    }
+
+    pub const fn data_size(&self) -> u32 {
+        self.sample_count as u32 * OFFLINE_LOG_SAMPLE_SIZE as u32
+    }
+
+    /// Duration implied by the sample count and interval.
+    pub fn calculated_duration(&self) -> Time {
+        self.interval * f64::from(self.sample_count.saturating_sub(1))
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        LogMetadataWire {
+            filename: self.filename_raw,
+            unknown_0x10: U16::new(self.unknown_0x10),
+            sample_count: U16::new(self.sample_count),
+            interval_ms: U16::new(self.interval.get::<millisecond>() as u16),
+            flags: U16::new(self.flags),
+            recorded_duration_seconds: U32::new(self.recorded_duration.get::<second>() as u32),
+            opaque_tail: self.opaque_tail,
+        }
+        .as_bytes()
+        .to_vec()
+    }
+}
+
+/// Response to a `LogMetadata` request.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum LogMetadataResponse {
+    /// No offline log is currently available.
+    Empty,
+    Available(LogMetadata),
+}
+
+#[cfg(feature = "python")]
+impl<'py> pyo3::IntoPyObject<'py> for LogMetadataResponse {
+    type Target = pyo3::PyAny;
+    type Output = pyo3::Bound<'py, Self::Target>;
+    type Error = pyo3::PyErr;
+
+    fn into_pyobject(self, py: pyo3::Python<'py>) -> Result<Self::Output, Self::Error> {
+        match self {
+            Self::Empty => Ok(py.None().into_bound(py)),
+            Self::Available(metadata) => Ok(metadata.into_pyobject(py)?.into_any()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+struct OfflineLogSampleWire {
+    voltage_uv: I32,
+    current_ua: I32,
+    charge_uah: I32,
+    energy_uwh: I32,
+}
+
+/// Lossless wire representation of one offline log sample.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct OfflineLogSampleRaw {
+    pub voltage_uv: i32,
+    pub current_ua: i32,
+    pub charge_uah: i32,
+    pub energy_uwh: i32,
+}
+
+impl OfflineLogSampleRaw {
+    pub fn decode(self) -> OfflineLogSample {
+        let voltage = ElectricPotential::new::<microvolt>(f64::from(self.voltage_uv));
+        let current = ElectricCurrent::new::<microampere>(f64::from(self.current_ua));
+        OfflineLogSample {
+            raw: self,
+            voltage,
+            current,
+            power: voltage * current,
+            charge: ElectricCharge::new::<microampere_hour>(f64::from(self.charge_uah)),
+            energy: Energy::new::<microwatt_hour>(f64::from(self.energy_uwh)),
+        }
+    }
+}
+
+impl From<OfflineLogSampleWire> for OfflineLogSampleRaw {
+    fn from(wire: OfflineLogSampleWire) -> Self {
+        Self {
+            voltage_uv: wire.voltage_uv.get(),
+            current_ua: wire.current_ua.get(),
+            charge_uah: wire.charge_uah.get(),
+            energy_uwh: wire.energy_uwh.get(),
+        }
+    }
+}
+
+impl From<OfflineLogSampleRaw> for OfflineLogSampleWire {
+    fn from(raw: OfflineLogSampleRaw) -> Self {
+        Self {
+            voltage_uv: I32::new(raw.voltage_uv),
+            current_ua: I32::new(raw.current_ua),
+            charge_uah: I32::new(raw.charge_uah),
+            energy_uwh: I32::new(raw.energy_uwh),
+        }
+    }
+}
+
+/// One decoded offline log sample with typed physical quantities.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct OfflineLogSample {
+    raw: OfflineLogSampleRaw,
+    pub voltage: ElectricPotential,
+    pub current: ElectricCurrent,
+    pub power: Power,
+    pub charge: ElectricCharge,
+    pub energy: Energy,
+}
+
+impl OfflineLogSample {
+    pub const fn raw(&self) -> OfflineLogSampleRaw {
+        self.raw
+    }
+}
+
+/// A complete offline log downloaded from the device.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct OfflineLog {
+    pub metadata: LogMetadata,
+    pub samples: Vec<OfflineLogSample>,
+}
+
+impl OfflineLog {
+    pub fn from_bytes(metadata: LogMetadata, bytes: &[u8]) -> Result<Self, KMError> {
+        let expected = metadata.data_size() as usize;
+        if bytes.len() != expected {
+            return Err(KMError::InvalidPacket(format!(
+                "Offline log data length mismatch: metadata expects {expected} bytes, got {}",
+                bytes.len()
+            )));
+        }
+
+        let samples = bytes
+            .chunks_exact(OFFLINE_LOG_SAMPLE_SIZE)
+            .map(|bytes| {
+                OfflineLogSampleWire::ref_from_bytes(bytes)
+                    .map(|wire| OfflineLogSampleRaw::from(*wire).decode())
+                    .map_err(|_| KMError::InvalidPacket("Failed to parse offline log sample".to_string()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self { metadata, samples })
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.samples
+            .iter()
+            .flat_map(|sample| OfflineLogSampleWire::from(sample.raw()).as_bytes().to_vec())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uom::si::electric_charge::milliampere_hour;
+    use uom::si::electric_current::ampere;
+    use uom::si::electric_potential::volt;
+    use uom::si::energy::milliwatt_hour;
+    use uom::si::time::{millisecond, second};
+
+    use super::*;
+
+    const CAPTURED_METADATA: &str = concat!(
+        "4130312e640000000000000000000000",
+        "450a09021027000050140000",
+        "a1a2f3ffe04da8ff000000000000000000000000"
+    );
+
+    #[test]
+    fn parses_and_round_trips_captured_metadata() {
+        let bytes = hex::decode(CAPTURED_METADATA).unwrap();
+        let metadata = LogMetadata::from_bytes(&bytes).unwrap();
+
+        assert_eq!(metadata.filename().unwrap(), "A01.d");
+        assert_eq!(metadata.unknown_0x10, 0x0a45);
+        assert_eq!(metadata.sample_count, 521);
+        assert_eq!(metadata.interval.get::<millisecond>(), 10_000.0);
+        assert_eq!(metadata.flags, 0);
+        assert_eq!(metadata.recorded_duration.get::<second>(), 5_200.0);
+        assert_eq!(metadata.calculated_duration().get::<second>(), 5_200.0);
+        assert_eq!(metadata.data_size(), 8_336);
+        assert_eq!(metadata.to_bytes(), bytes);
+    }
+
+    #[test]
+    fn parses_and_round_trips_captured_samples() {
+        let raw_samples = [
+            "81494c0021f0e2ff56ebffffb998ffff",
+            "bcaa89006e25f2ff2dd5f8fff7fdd6ff",
+            "cf2a8900947dfeffa1a2f3ffe04da8ff",
+        ]
+        .into_iter()
+        .flat_map(|sample| hex::decode(sample).unwrap())
+        .collect::<Vec<_>>();
+        let mut metadata = LogMetadata::from_bytes(&hex::decode(CAPTURED_METADATA).unwrap()).unwrap();
+        metadata.sample_count = 3;
+        let log = OfflineLog::from_bytes(metadata, &raw_samples).unwrap();
+
+        assert_eq!(log.samples[0].voltage.get::<volt>(), 4.999_553);
+        assert_eq!(log.samples[0].current.get::<ampere>(), -1.904_607);
+        assert_eq!(log.samples[0].charge.get::<milliampere_hour>(), -5.29);
+        assert!((log.samples[0].energy.get::<milliwatt_hour>() + 26.439).abs() < 1e-12);
+        assert_eq!(log.samples[1].raw().charge_uah, -469_715);
+        assert_eq!(log.samples[1].raw().energy_uwh, -2_687_497);
+        assert_eq!(log.samples[2].raw().voltage_uv, 8_989_391);
+        assert_eq!(log.to_bytes(), raw_samples);
+    }
+
+    #[test]
+    fn rejects_wrong_metadata_and_log_sizes() {
+        assert!(LogMetadata::from_bytes(&[0; LOG_METADATA_SIZE - 1]).is_err());
+        let mut metadata = LogMetadata::from_bytes(&hex::decode(CAPTURED_METADATA).unwrap()).unwrap();
+        metadata.sample_count = 1;
+        assert!(OfflineLog::from_bytes(metadata, &[0; OFFLINE_LOG_SAMPLE_SIZE - 1]).is_err());
+    }
+
+    #[test]
+    fn parses_available_and_empty_captured_metadata_responses() {
+        use bytes::Bytes;
+
+        use crate::{Packet, RawPacket};
+
+        let available = hex::decode(concat!(
+            "4107c2020002000c",
+            "4130312e640000000000000000000000",
+            "450a09021027000050140000",
+            "a1a2f3ffe04da8ff000000000000000000000000"
+        ))
+        .unwrap();
+        let packet = Packet::try_from(RawPacket::try_from(Bytes::from(available)).unwrap()).unwrap();
+        assert!(matches!(
+            packet.get_log_metadata(),
+            Some(LogMetadataResponse::Available(metadata)) if metadata.sample_count == 521
+        ));
+
+        let empty = hex::decode("4108c2ff00020000").unwrap();
+        let packet = Packet::try_from(RawPacket::try_from(Bytes::from(empty)).unwrap()).unwrap();
+        assert_eq!(packet.get_log_metadata(), Some(&LogMetadataResponse::Empty));
+    }
+}

--- a/km003c-lib/src/offline.rs
+++ b/km003c-lib/src/offline.rs
@@ -30,7 +30,10 @@ struct LogMetadataWire {
     interval_ms: U16,
     flags: U16,
     recorded_duration_seconds: U32,
-    opaque_tail: [u8; 20],
+    final_charge_uah: I32,
+    final_energy_uwh: I32,
+    data_offset: U32,
+    reserved_tail: [u8; 8],
 }
 
 /// Metadata describing the offline log selected on the device.
@@ -47,7 +50,11 @@ pub struct LogMetadata {
     pub interval: Time,
     pub flags: u16,
     pub recorded_duration: Time,
-    pub opaque_tail: [u8; 20],
+    pub final_charge: ElectricCharge,
+    pub final_energy: Energy,
+    /// Offset from `OFFLINE_LOG_ADDRESS` at which this log's samples begin.
+    pub data_offset: u32,
+    pub reserved_tail: [u8; 8],
 }
 
 impl LogMetadata {
@@ -69,7 +76,10 @@ impl LogMetadata {
             interval: Time::new::<millisecond>(f64::from(wire.interval_ms.get())),
             flags: wire.flags.get(),
             recorded_duration: Time::new::<second>(f64::from(wire.recorded_duration_seconds.get())),
-            opaque_tail: wire.opaque_tail,
+            final_charge: ElectricCharge::new::<microampere_hour>(f64::from(wire.final_charge_uah.get())),
+            final_energy: Energy::new::<microwatt_hour>(f64::from(wire.final_energy_uwh.get())),
+            data_offset: wire.data_offset.get(),
+            reserved_tail: wire.reserved_tail,
         })
     }
 
@@ -95,6 +105,23 @@ impl LogMetadata {
         self.sample_count as u32 * OFFLINE_LOG_SAMPLE_SIZE as u32
     }
 
+    pub fn data_address(&self) -> Result<u32, KMError> {
+        OFFLINE_LOG_ADDRESS.checked_add(self.data_offset).ok_or_else(|| {
+            KMError::Protocol(format!(
+                "Offline log data offset 0x{:08X} overflows the base address",
+                self.data_offset
+            ))
+        })
+    }
+
+    pub fn final_charge_raw_uah(&self) -> i32 {
+        self.final_charge.get::<microampere_hour>().round() as i32
+    }
+
+    pub fn final_energy_raw_uwh(&self) -> i32 {
+        self.final_energy.get::<microwatt_hour>().round() as i32
+    }
+
     /// Duration implied by the sample count and interval.
     pub fn calculated_duration(&self) -> Time {
         self.interval * f64::from(self.sample_count.saturating_sub(1))
@@ -105,10 +132,13 @@ impl LogMetadata {
             filename: self.filename_raw,
             unknown_0x10: U16::new(self.unknown_0x10),
             sample_count: U16::new(self.sample_count),
-            interval_ms: U16::new(self.interval.get::<millisecond>() as u16),
+            interval_ms: U16::new(self.interval.get::<millisecond>().round() as u16),
             flags: U16::new(self.flags),
-            recorded_duration_seconds: U32::new(self.recorded_duration.get::<second>() as u32),
-            opaque_tail: self.opaque_tail,
+            recorded_duration_seconds: U32::new(self.recorded_duration.get::<second>().round() as u32),
+            final_charge_uah: I32::new(self.final_charge_raw_uah()),
+            final_energy_uwh: I32::new(self.final_energy_raw_uwh()),
+            data_offset: U32::new(self.data_offset),
+            reserved_tail: self.reserved_tail,
         }
         .as_bytes()
         .to_vec()
@@ -121,7 +151,7 @@ impl LogMetadata {
 pub enum LogMetadataResponse {
     /// No offline log is currently available.
     Empty,
-    Available(LogMetadata),
+    Available(Vec<LogMetadata>),
 }
 
 #[cfg(feature = "python")]
@@ -239,6 +269,19 @@ impl OfflineLog {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
+        if let Some(last) = samples.last() {
+            let raw = last.raw();
+            if raw.charge_uah != metadata.final_charge_raw_uah() || raw.energy_uwh != metadata.final_energy_raw_uwh() {
+                return Err(KMError::InvalidPacket(format!(
+                    "Offline log final accumulators do not match metadata: sample has charge={} µAh and energy={} µWh, metadata has charge={} µAh and energy={} µWh",
+                    raw.charge_uah,
+                    raw.energy_uwh,
+                    metadata.final_charge_raw_uah(),
+                    metadata.final_energy_raw_uwh()
+                )));
+            }
+        }
+
         Ok(Self { metadata, samples })
     }
 
@@ -279,6 +322,10 @@ mod tests {
         assert_eq!(metadata.recorded_duration.get::<second>(), 5_200.0);
         assert_eq!(metadata.calculated_duration().get::<second>(), 5_200.0);
         assert_eq!(metadata.data_size(), 8_336);
+        assert_eq!(metadata.final_charge.get::<microampere_hour>(), -810_335.0);
+        assert!((metadata.final_energy.get::<microwatt_hour>() + 5_747_232.0).abs() < 1e-8);
+        assert_eq!(metadata.data_offset, 0);
+        assert_eq!(metadata.reserved_tail, [0; 8]);
         assert_eq!(metadata.to_bytes(), bytes);
     }
 
@@ -315,6 +362,15 @@ mod tests {
     }
 
     #[test]
+    fn rejects_data_from_the_wrong_catalog_entry() {
+        let mut metadata = LogMetadata::from_bytes(&hex::decode(CAPTURED_METADATA).unwrap()).unwrap();
+        metadata.sample_count = 1;
+        let wrong_sample = hex::decode("81494c0021f0e2ff56ebffffb998ffff").unwrap();
+        let error = OfflineLog::from_bytes(metadata, &wrong_sample).unwrap_err();
+        assert!(error.to_string().contains("final accumulators do not match"));
+    }
+
+    #[test]
     fn parses_available_and_empty_captured_metadata_responses() {
         use bytes::Bytes;
 
@@ -330,7 +386,7 @@ mod tests {
         let packet = Packet::try_from(RawPacket::try_from(Bytes::from(available)).unwrap()).unwrap();
         assert!(matches!(
             packet.get_log_metadata(),
-            Some(LogMetadataResponse::Available(metadata)) if metadata.sample_count == 521
+            Some(LogMetadataResponse::Available(metadata)) if metadata.len() == 1 && metadata[0].sample_count == 521
         ));
 
         let empty = hex::decode("4108c2ff00020000").unwrap();


### PR DESCRIPTION
## Summary

- parse empty, single-entry, and multi-entry `LogMetadata` catalogs
- expose typed `uom` metadata and 16-byte offline samples
- download each recording from its catalog-provided flash offset
- reject data whose final charge/energy accumulators do not match metadata
- add the `offline-log` CLI with metadata inspection and CSV/JSON export
- document the library API and CLI workflow

## Why

The earlier research capture contained one 48-byte metadata entry, which made the response look singular and the log address look fixed at `0x98100000`. Live testing found a 144-byte catalog with three entries. Each entry carries its own data offset; always reading the base address would return the first log while labeling it as another one.

## Validation

- `cargo test --workspace --all-features --locked`
- `cargo clippy --workspace --all-features --all-targets --locked -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps --locked`
- capture-backed parsing and round-trip tests for metadata and samples
- live KM003C: downloaded A01 (521 samples), A02 (2), and A03 (2036) from offsets `0x0000`, `0x2200`, and `0x2400`
- live KM003C: final charge and energy matched metadata for all three logs
- legacy Python downloader auth/init and A02 download remained functional

The matching protocol documentation and research-script fixes were pushed directly to `km003c-protocol-research` main as commit `bdf24c8`.