### PR TITLE
Add hardware-verified level 2 calibration authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `offline-log` CLI with metadata inspection and CSV/JSON export.
 - Explicit-rate AdcQueue decoding in Python through
   `AdcQueueRawData.decode()` and `parse_packet_with_graph_rate()`.
+- Level-2 calibration authentication through
+  `KM003C::authenticate_calibration()`.
+- `AuthCredential` distinguishes the StreamingAuth credential from a device
+  `HardwareId`.
 
 ### Changed
 
+- `Packet::StreamingAuth` and its Python dictionary representation now name
+  their 12-byte value `credential` instead of incorrectly assuming it is
+  always a HardwareID.
 - Context-free AdcQueue parsing now returns `AdcQueueRawData`; use
   `decode(GraphSampleRate)` when the `StartGraph` rate is known.
 - `AdcQueueData` stores its configured `rate`, and

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ values in the Rust API are type-safe [`uom`](https://docs.rs/uom) quantities.
 Core library providing:
 - Device communication and automatic initialization
 - Streaming authentication (required for AdcQueue)
+- Firmware-selected calibration authentication for level-2 operations
 - ADC and AdcQueue data parsing
 - Offline recording catalog and encrypted log downloads
 - USB PD event parsing

--- a/km003c-lib/README.md
+++ b/km003c-lib/README.md
@@ -12,6 +12,10 @@ Offline recordings are exposed as a catalog of typed `LogMetadata` entries.
 `KM003C::download_offline_log()` selects the correct flash offset, validates
 the final charge and energy accumulators, and returns typed `uom` samples.
 
+Normal vendor initialization authenticates with the device HardwareID at
+level 1. `KM003C::authenticate_calibration()` safely reads the firmware-selected
+calibration credential and requests level 2 without writing device memory.
+
 Enable the optional `usbpd` feature to turn captured PD wire frames into typed
 USB PD messages. `PdSessionDecoder` retains Source Capabilities state for
 subsequent Request messages and reassembles chunked EPR Source Capabilities.

--- a/km003c-lib/examples/calibration_auth.rs
+++ b/km003c-lib/examples/calibration_auth.rs
@@ -1,0 +1,27 @@
+use std::time::Duration;
+
+use km003c_lib::{Attribute, AttributeSet, DeviceConfig, GraphSampleRate, KM003C};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut device = KM003C::new(DeviceConfig::vendor().skip_reset()).await?;
+    let initial_level = device.state().map(|state| state.auth_level).unwrap_or(0);
+    println!("Initial authentication level: {initial_level}");
+
+    let result = device.authenticate_calibration().await?;
+    println!(
+        "Calibration authentication level: {} (attribute 0x{:04x})",
+        result.auth_level, result.attribute
+    );
+
+    device.start_graph_mode(GraphSampleRate::Sps50).await?;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let response = device.request_data(AttributeSet::single(Attribute::AdcQueue)).await;
+    device.stop_graph_mode().await?;
+
+    let response = response?;
+    let samples = response.get_adc_queue().map(|queue| queue.samples.len()).unwrap_or(0);
+    println!("AdcQueue samples received after level-2 auth: {samples}");
+
+    Ok(())
+}

--- a/km003c-lib/src/auth.rs
+++ b/km003c-lib/src/auth.rs
@@ -62,8 +62,14 @@ pub const FIRMWARE_INFO_ADDRESS: u32 = 0x00004420;
 /// Memory address for CalibrationData (serial, UUID, timestamp)
 pub const CALIBRATION_ADDRESS: u32 = 0x03000C00;
 
+/// Preferred calibration record used for level-2 authentication when present.
+pub const PREFERRED_CALIBRATION_ADDRESS: u32 = 0x03000D80;
+
 /// Size of info blocks (DeviceInfo, FirmwareInfo, Calibration)
 pub const INFO_BLOCK_SIZE: usize = 64;
+
+/// Size of the credential embedded in a StreamingAuth request.
+pub const STREAMING_AUTH_CREDENTIAL_SIZE: usize = 12;
 
 /// 12-byte Hardware ID read from device memory at 0x40010450
 ///
@@ -107,6 +113,39 @@ impl HardwareId {
 impl std::fmt::Display for HardwareId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", hex::encode(self.bytes))
+    }
+}
+
+/// Opaque 12-byte credential embedded in a StreamingAuth request.
+///
+/// Firmware V1.9.9 accepts the device HardwareID for auth level 1 and the
+/// beginning of its selected calibration record for auth level 2.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthCredential {
+    bytes: [u8; STREAMING_AUTH_CREDENTIAL_SIZE],
+}
+
+impl AuthCredential {
+    /// Create a credential from its exact wire bytes.
+    pub fn from_bytes(bytes: [u8; STREAMING_AUTH_CREDENTIAL_SIZE]) -> Self {
+        Self { bytes }
+    }
+
+    /// Return the exact credential bytes.
+    pub fn as_bytes(&self) -> &[u8; STREAMING_AUTH_CREDENTIAL_SIZE] {
+        &self.bytes
+    }
+}
+
+impl From<&HardwareId> for AuthCredential {
+    fn from(hardware_id: &HardwareId) -> Self {
+        Self::from_bytes(*hardware_id.as_bytes())
+    }
+}
+
+impl From<HardwareId> for AuthCredential {
+    fn from(hardware_id: HardwareId) -> Self {
+        Self::from(&hardware_id)
     }
 }
 
@@ -303,11 +342,11 @@ pub fn build_memory_read_packet(address: u32, size: u32, tid: u8) -> Vec<u8> {
 /// Build StreamingAuth encrypted payload (32 bytes)
 ///
 /// # Arguments
-/// * `hardware_id` - 12-byte HardwareID from device
+/// * `credential` - 12-byte device or calibration credential
 ///
 /// # Returns
 /// 32-byte AES-encrypted payload
-pub fn build_streaming_auth_payload(hardware_id: &HardwareId) -> [u8; 32] {
+pub fn build_streaming_auth_payload(credential: &AuthCredential) -> [u8; 32] {
     // Build 32-byte plaintext
     let mut plaintext = [0u8; 32];
 
@@ -318,8 +357,8 @@ pub fn build_streaming_auth_payload(hardware_id: &HardwareId) -> [u8; 32] {
         .unwrap_or(0);
     plaintext[0..8].copy_from_slice(&timestamp.to_le_bytes());
 
-    // Bytes 8-19: HardwareID (12 bytes) - THIS IS THE CRITICAL PART
-    plaintext[8..20].copy_from_slice(hardware_id.as_bytes());
+    // Bytes 8-19: device or calibration authentication credential
+    plaintext[8..20].copy_from_slice(credential.as_bytes());
 
     // Bytes 20-31: Random padding
     let random_bytes: [u8; 12] = rand::random();
@@ -329,11 +368,11 @@ pub fn build_streaming_auth_payload(hardware_id: &HardwareId) -> [u8; 32] {
     aes_ecb_encrypt(&plaintext, STREAMING_AUTH_KEY_ENC)
 }
 
-/// Decrypt a host-to-device StreamingAuth request and extract its HardwareID.
-pub fn parse_streaming_auth_request_payload(ciphertext: &[u8]) -> Option<HardwareId> {
+/// Decrypt a host-to-device StreamingAuth request and extract its credential.
+pub fn parse_streaming_auth_request_payload(ciphertext: &[u8]) -> Option<AuthCredential> {
     let encrypted: [u8; STREAMING_AUTH_PAYLOAD_SIZE] = ciphertext.try_into().ok()?;
     let plaintext = aes_ecb_decrypt(&encrypted, STREAMING_AUTH_KEY_ENC);
-    Some(HardwareId::from_bytes(plaintext[8..20].try_into().ok()?))
+    Some(AuthCredential::from_bytes(plaintext[8..20].try_into().ok()?))
 }
 
 /// Encrypt a StreamingAuth payload (for serializing responses)
@@ -350,13 +389,13 @@ pub fn encrypt_streaming_auth_response_payload(plaintext: &[u8; 32]) -> [u8; 32]
 /// Build a StreamingAuth (0x4C) request packet
 ///
 /// # Arguments
-/// * `hardware_id` - 12-byte HardwareID from device
+/// * `credential` - 12-byte device or calibration credential
 /// * `tid` - Transaction ID
 ///
 /// # Returns
 /// 36-byte packet: 4-byte header + 32-byte AES-encrypted payload
-pub fn build_streaming_auth_packet(hardware_id: &HardwareId, tid: u8) -> Vec<u8> {
-    let ciphertext = build_streaming_auth_payload(hardware_id);
+pub fn build_streaming_auth_packet(credential: &AuthCredential, tid: u8) -> Vec<u8> {
+    let ciphertext = build_streaming_auth_payload(credential);
 
     // Build packet: header + encrypted payload
     let mut packet = Vec::with_capacity(36);
@@ -554,12 +593,20 @@ mod tests {
     #[test]
     fn test_streaming_auth_packet_structure() {
         let hw_id = HardwareId::from_bytes([0x30, 0x37, 0x31, 0x4b, 0x42, 0x50, 0x0d, 0xff, 0x11, 0x0a, 0xff, 0xff]);
-        let packet = build_streaming_auth_packet(&hw_id, 0x06);
+        let packet = build_streaming_auth_packet(&AuthCredential::from(&hw_id), 0x06);
         assert_eq!(packet.len(), 36);
         assert_eq!(packet[0], 0x4C); // StreamingAuth
         assert_eq!(packet[1], 0x06); // TID
         assert_eq!(packet[2], 0x00); // Attribute low
         assert_eq!(packet[3], 0x02); // Attribute high (0x0002)
+    }
+
+    #[test]
+    fn test_streaming_auth_calibration_credential_roundtrip() {
+        let credential = AuthCredential::from_bytes(*b"007965 CDFDD");
+        let encrypted = build_streaming_auth_payload(&credential);
+
+        assert_eq!(parse_streaming_auth_request_payload(&encrypted), Some(credential));
     }
 
     #[test]
@@ -718,7 +765,7 @@ mod tests {
         ]);
 
         // Generate StreamingAuth packet
-        let packet = build_streaming_auth_packet(&hw_id, 0x06);
+        let packet = build_streaming_auth_packet(&AuthCredential::from(&hw_id), 0x06);
 
         // Verify header matches hardcoded
         let hardcoded = hex::decode(HARDCODED_STREAMING_AUTH).unwrap();

--- a/km003c-lib/src/device.rs
+++ b/km003c-lib/src/device.rs
@@ -44,7 +44,10 @@
 
 use crate::adc::AdcDataSimple;
 use crate::adcqueue::GraphSampleRate;
-use crate::auth::{DeviceInfo, HardwareId};
+use crate::auth::{
+    AuthCredential, CALIBRATION_ADDRESS, DeviceInfo, HardwareId, PREFERRED_CALIBRATION_ADDRESS,
+    STREAMING_AUTH_CREDENTIAL_SIZE, StreamingAuthResult,
+};
 use crate::error::KMError;
 use crate::message::Packet;
 use crate::offline::{LogMetadata, LogMetadataResponse, OfflineLog};
@@ -60,6 +63,10 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::timeout;
 use tracing::{debug, info, trace, warn};
+
+fn calibration_record_is_erased(record: &[u8]) -> bool {
+    record.starts_with(&[0xff; 4])
+}
 
 /// Device state populated by initialization
 ///
@@ -594,8 +601,8 @@ impl KM003C {
                 self.send_raw(&raw).await?;
                 return Ok(id);
             }
-            Packet::StreamingAuth { hardware_id } => {
-                let raw = auth::build_streaming_auth_packet(hardware_id, id);
+            Packet::StreamingAuth { credential } => {
+                let raw = auth::build_streaming_auth_packet(credential, id);
                 self.send_raw(&raw).await?;
                 return Ok(id);
             }
@@ -965,25 +972,7 @@ impl KM003C {
         };
 
         // 6. StreamingAuth
-        self.send_tracked(Packet::StreamingAuth {
-            hardware_id: hardware_id.clone(),
-        })
-        .await?;
-        let auth_response = self
-            // StreamingAuth is the documented exception to normal transaction
-            // correlation: captured device responses always carry ID 0.
-            .receive_matching_raw(|bytes| response_type_matches(bytes, PacketType::StreamingAuth))
-            .await?;
-
-        let auth = match Self::parse_response(auth_response, self.graph_sample_rate)? {
-            Packet::StreamingAuthResponse(result) => result,
-            other => {
-                return Err(KMError::Protocol(format!(
-                    "Expected StreamingAuthResponse, got {:?}",
-                    other
-                )));
-            }
-        };
+        let auth = self.perform_streaming_auth(AuthCredential::from(&hardware_id)).await?;
 
         // Store device state in Full mode
         let state = DeviceState {
@@ -998,6 +987,22 @@ impl KM003C {
         self.mode = ConnectionMode::Full(state);
 
         Ok(())
+    }
+
+    async fn perform_streaming_auth(&mut self, credential: AuthCredential) -> Result<StreamingAuthResult, KMError> {
+        self.send_tracked(Packet::StreamingAuth { credential }).await?;
+        let response = self
+            // StreamingAuth is the documented exception to normal transaction
+            // correlation: captured device responses always carry ID 0.
+            .receive_matching_raw(|bytes| response_type_matches(bytes, PacketType::StreamingAuth))
+            .await?;
+
+        match Self::parse_response(response, self.graph_sample_rate)? {
+            Packet::StreamingAuthResponse(result) => Ok(result),
+            other => Err(KMError::Protocol(format!(
+                "Expected StreamingAuthResponse, got {other:?}"
+            ))),
+        }
     }
 
     /// Get the current connection mode
@@ -1041,6 +1046,51 @@ impl KM003C {
     /// Returns `false` in Basic mode or if not authenticated for streaming.
     pub fn adcqueue_enabled(&self) -> bool {
         self.state().map(|s| s.adcqueue_enabled).unwrap_or(false)
+    }
+
+    /// Authenticate with the device's calibration credential and enter auth level 2.
+    ///
+    /// KM003C firmware V1.9.9 prefers the first 12 bytes at `0x03000D80`.
+    /// When that record starts with `0xFFFFFFFF`, it falls back to
+    /// `0x03000C00`. This method only reads those known addresses and sends a
+    /// StreamingAuth request; it does not write settings or flash memory.
+    pub async fn authenticate_calibration(&mut self) -> Result<StreamingAuthResult, KMError> {
+        if !self.is_full_mode() {
+            return Err(KMError::Protocol(
+                "Calibration authentication requires the vendor interface".to_string(),
+            ));
+        }
+
+        let preferred = self
+            .read_memory_block(PREFERRED_CALIBRATION_ADDRESS, STREAMING_AUTH_CREDENTIAL_SIZE as u32)
+            .await?;
+        let selected = if calibration_record_is_erased(&preferred) {
+            self.read_memory_block(CALIBRATION_ADDRESS, STREAMING_AUTH_CREDENTIAL_SIZE as u32)
+                .await?
+        } else {
+            preferred
+        };
+        let credential = AuthCredential::from_bytes(
+            selected
+                .as_slice()
+                .try_into()
+                .map_err(|_| KMError::Protocol("Calibration credential has the wrong length".to_string()))?,
+        );
+        let result = self.perform_streaming_auth(credential).await?;
+
+        if result.auth_level != 2 {
+            return Err(KMError::Protocol(format!(
+                "Calibration authentication returned level {} instead of 2",
+                result.auth_level
+            )));
+        }
+
+        if let ConnectionMode::Full(state) = &mut self.mode {
+            state.auth_level = result.auth_level;
+            state.adcqueue_enabled = result.adcqueue_enabled();
+        }
+
+        Ok(result)
     }
 
     /// Read an encrypted memory block from the device
@@ -1201,6 +1251,13 @@ impl KM003C {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn calibration_auth_falls_back_only_for_an_erased_preferred_record() {
+        assert!(calibration_record_is_erased(&[0xff; STREAMING_AUTH_CREDENTIAL_SIZE]));
+        assert!(!calibration_record_is_erased(b"007965 CDFDD"));
+        assert!(!calibration_record_is_erased(&[0xff, 0xff, 0xff]));
+    }
 
     #[test]
     fn response_matching_uses_the_typed_header_parser() {

--- a/km003c-lib/src/lib.rs
+++ b/km003c-lib/src/lib.rs
@@ -21,7 +21,7 @@ pub use python::*;
 pub use adcqueue::{
     AdcQueueData, AdcQueueRawData, AdcQueueSample, AdcQueueSampleRaw, GraphSampleRate, sequence_elapsed,
 };
-pub use auth::{DeviceInfo, HardwareId, StreamingAuthResult};
+pub use auth::{AuthCredential, DeviceInfo, HardwareId, StreamingAuthResult};
 pub use device::{ConnectionMode, DeviceConfig, DeviceState, KM003C, TransferType};
 pub use message::{Packet, PayloadData};
 pub use offline::{LogMetadata, LogMetadataResponse, OfflineLog, OfflineLogSample, OfflineLogSampleRaw};

--- a/km003c-lib/src/message.rs
+++ b/km003c-lib/src/message.rs
@@ -1,6 +1,6 @@
 use crate::adc::{AdcDataRaw, AdcDataSimple};
 use crate::adcqueue::{AdcQueueData, AdcQueueRawData, GraphSampleRate};
-use crate::auth::{self, HardwareId, StreamingAuthResult};
+use crate::auth::{self, AuthCredential, StreamingAuthResult};
 use crate::constants::*;
 use crate::error::KMError;
 use crate::offline::{LogMetadata, LogMetadataResponse};
@@ -64,8 +64,8 @@ pub enum Packet {
     },
     /// StreamingAuth command (0x4C) - authenticate for AdcQueue streaming
     StreamingAuth {
-        /// HardwareID to authenticate with
-        hardware_id: HardwareId,
+        /// Device or calibration credential to authenticate with
+        credential: AuthCredential,
     },
     /// StreamingAuth response (0x4C) - authentication result
     StreamingAuthResponse(StreamingAuthResult),
@@ -212,9 +212,9 @@ impl Packet {
                     PacketType::StreamingAuth => {
                         let auth_header = StreamingAuthHeader::from_bytes(header.into_bytes());
                         if auth_header.attribute() == 0x0200
-                            && let Some(hardware_id) = auth::parse_streaming_auth_request_payload(&payload)
+                            && let Some(credential) = auth::parse_streaming_auth_request_payload(&payload)
                         {
-                            Ok(Packet::StreamingAuth { hardware_id })
+                            Ok(Packet::StreamingAuth { credential })
                         } else if let Some(result) = auth::parse_streaming_auth_response_parts(auth_header, &payload) {
                             Ok(Packet::StreamingAuthResponse(result))
                         } else {
@@ -495,9 +495,9 @@ impl Packet {
                     payload: encrypted_payload.to_vec(),
                 }
             }
-            Packet::StreamingAuth { hardware_id } => {
+            Packet::StreamingAuth { credential } => {
                 // Build encrypted StreamingAuth payload
-                let encrypted_payload = auth::build_streaming_auth_payload(&hardware_id);
+                let encrypted_payload = auth::build_streaming_auth_payload(&credential);
                 RawPacket::SimpleData {
                     header: DataHeader::from_bytes([PacketType::StreamingAuth.into(), id, 0x00, 0x02]),
                     payload: encrypted_payload.to_vec(),
@@ -586,9 +586,9 @@ impl<'py> pyo3::IntoPyObject<'py> for Packet {
                 inner.set_item("size", size)?;
                 dict.set_item("MemoryRead", inner)?;
             }
-            Packet::StreamingAuth { hardware_id } => {
+            Packet::StreamingAuth { credential } => {
                 let inner = PyDict::new(py);
-                inner.set_item("hardware_id", hex::encode(hardware_id.bytes))?;
+                inner.set_item("credential", hex::encode(credential.as_bytes()))?;
                 dict.set_item("StreamingAuth", inner)?;
             }
             Packet::StreamingAuthResponse(result) => {

--- a/km003c-lib/tests/roundtrip.rs
+++ b/km003c-lib/tests/roundtrip.rs
@@ -36,12 +36,12 @@ fn captured_auth_requests_roundtrip_as_semantic_packets() {
     let auth =
         Bytes::from(hex::decode("4c0600025538815b69a452c83e54ef1d70f3bc9ae6aac1b12a6ac07c20fde58c7bf517ca").unwrap());
     let auth_packet = Packet::try_from(RawPacket::try_from(auth).unwrap()).unwrap();
-    let Packet::StreamingAuth { hardware_id } = auth_packet else {
+    let Packet::StreamingAuth { credential } = auth_packet else {
         panic!("captured StreamingAuth request did not parse semantically");
     };
-    assert_eq!(hardware_id.as_bytes(), b"071KBP\r\xff\x11\n\xff\xff");
+    assert_eq!(credential.as_bytes(), b"071KBP\r\xff\x11\n\xff\xff");
 
-    let serialized = Bytes::from(Packet::StreamingAuth { hardware_id }.to_raw_packet(6).unwrap());
+    let serialized = Bytes::from(Packet::StreamingAuth { credential }.to_raw_packet(6).unwrap());
     assert_eq!(&serialized[..4], &[0x4c, 0x06, 0x00, 0x02]);
     assert!(matches!(
         Packet::try_from(RawPacket::try_from(serialized).unwrap()).unwrap(),

--- a/km003c-lib/tests/serialization.rs
+++ b/km003c-lib/tests/serialization.rs
@@ -50,7 +50,13 @@ fn auth_requests_use_their_special_wire_headers() {
     let hardware_id = km003c_lib::auth::HardwareId::from_bytes([
         0x30, 0x37, 0x31, 0x4b, 0x42, 0x50, 0x0d, 0xff, 0x11, 0x0a, 0xff, 0xff,
     ]);
-    let streaming_auth = Bytes::from(Packet::StreamingAuth { hardware_id }.to_raw_packet(6).unwrap());
+    let streaming_auth = Bytes::from(
+        Packet::StreamingAuth {
+            credential: (&hardware_id).into(),
+        }
+        .to_raw_packet(6)
+        .unwrap(),
+    );
 
     assert_eq!(&memory[..4], &[0x44, 0x02, 0x01, 0x01]);
     assert_eq!(&streaming_auth[..4], &[0x4c, 0x06, 0x00, 0x02]);


### PR DESCRIPTION
## What changed

- add `KM003C::authenticate_calibration()`, which follows the firmware V1.9.9 preferred-record/fallback selection and requests auth level 2
- add an opaque `AuthCredential` type instead of representing every StreamingAuth credential as a `HardwareId`
- update `Packet::StreamingAuth`, its Python dictionary representation, tests, examples, README, and changelog to use the corrected terminology
- factor the common StreamingAuth exchange so initialization and calibration auth share response handling

The high-level method reads only the known records at `0x03000D80` and, when that record is erased, `0x03000C00`. It does not write settings or flash memory.

## Why

Firmware reverse engineering established that StreamingAuth bytes 8-19 are a generic credential: HardwareID grants level 1, while the selected calibration record grants level 2. The previous public API encoded the level-1 interpretation directly into the packet type, so it could not accurately represent level-2 requests.

This intentionally changes the unreleased 0.3-facing packet API from `hardware_id` to `credential`.

## Hardware validation

Tested on a KM003C running firmware 1.9.9:

- normal initialization returned level 1
- calibration authentication returned level 2 with raw attribute `0x0205`
- AdcQueue remained usable after elevation: 10 samples were received at 50 SPS after a 200 ms accumulation interval

## Automated validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`