### PR TITLE
Add lossless read-only Settings parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `KM003C::authenticate_calibration()`.
 - `AuthCredential` distinguishes the StreamingAuth credential from a device
   `HardwareId`.
+- Lossless, CRC-validated, read-only Settings parsing with typed accessors for
+  firmware-confirmed fields and `KM003C::request_settings()`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Core library providing:
 - Streaming authentication (required for AdcQueue)
 - Firmware-selected calibration authentication for level-2 operations
 - ADC and AdcQueue data parsing
+- CRC-validated read-only device settings
 - Offline recording catalog and encrypted log downloads
 - USB PD event parsing
 - Optional stateful USB PD semantic decoding through the `usbpd` feature

--- a/km003c-lib/README.md
+++ b/km003c-lib/README.md
@@ -16,6 +16,11 @@ Normal vendor initialization authenticates with the device HardwareID at
 level 1. `KM003C::authenticate_calibration()` safely reads the firmware-selected
 calibration credential and requests level 2 without writing device memory.
 
+`KM003C::request_settings()` validates both persisted settings-block checksums
+and exposes only firmware-confirmed fields semantically. Unknown bytes remain
+available through the lossless raw block accessors; the API does not provide
+settings writes.
+
 Enable the optional `usbpd` feature to turn captured PD wire frames into typed
 USB PD messages. `PdSessionDecoder` retains Source Capabilities state for
 subsequent Request messages and reassembles chunked EPR Source Capabilities.

--- a/km003c-lib/examples/settings.rs
+++ b/km003c-lib/examples/settings.rs
@@ -1,0 +1,23 @@
+use km003c_lib::uom::si::ratio::percent;
+use km003c_lib::uom::si::time::microsecond;
+use km003c_lib::{DeviceConfig, KM003C};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut device = KM003C::new(DeviceConfig::vendor().skip_reset()).await?;
+    let settings = device.request_settings().await?;
+
+    println!("Device name: {}", settings.device_name().unwrap_or("<invalid UTF-8>"));
+    println!("Language selection: {}", settings.language_selection());
+    println!("Uncalibrated: {}", settings.is_uncalibrated());
+    println!("Brightness: {}%", settings.brightness().get::<percent>());
+    println!(
+        "Sample interval: {} us",
+        settings.sample_interval().get::<microsecond>()
+    );
+    println!("Screen orientation: {}", settings.screen_orientation());
+    println!("Mtools device mode: {}", settings.mtools_device_mode());
+    println!("Selected main page: {}", settings.selected_main_page());
+
+    Ok(())
+}

--- a/km003c-lib/src/device.rs
+++ b/km003c-lib/src/device.rs
@@ -53,6 +53,7 @@ use crate::message::Packet;
 use crate::offline::{LogMetadata, LogMetadataResponse, OfflineLog};
 use crate::packet::{Attribute, AttributeSet, PacketType, RawPacket};
 use crate::pd::{PdEventStream, PdStatus};
+use crate::settings::Settings;
 use bytes::Bytes;
 use nusb::Interface;
 use nusb::io::{EndpointRead, EndpointWrite};
@@ -836,6 +837,15 @@ impl KM003C {
             .get_adc()
             .cloned()
             .ok_or_else(|| KMError::Protocol("No ADC data in response".to_string()))
+    }
+
+    /// Request and parse the two read-only settings blocks.
+    pub async fn request_settings(&mut self) -> Result<Settings, KMError> {
+        let packet = self.request_data(AttributeSet::single(Attribute::Settings)).await?;
+        packet
+            .get_settings()
+            .cloned()
+            .ok_or_else(|| KMError::Protocol("No Settings data in response".to_string()))
     }
 
     /// Request metadata for the offline log currently selected on the device.

--- a/km003c-lib/src/lib.rs
+++ b/km003c-lib/src/lib.rs
@@ -10,6 +10,7 @@ pub mod packet;
 pub mod pd;
 #[cfg(feature = "usbpd")]
 pub mod pd_decode;
+pub mod settings;
 
 #[cfg(feature = "python")]
 pub mod python;
@@ -31,6 +32,7 @@ pub use pd::{PdEvent, PdEventData, PdEventStream, PdStatus};
 pub use pd_decode::{
     DecodedPdEvent, DecodedPdMessage, PdChunkState, PdChunkStatus, PdDecodeError, PdDecodeFailure, PdSessionDecoder,
 };
+pub use settings::Settings;
 pub use uom;
 #[cfg(feature = "usbpd")]
 pub use usbpd;

--- a/km003c-lib/src/message.rs
+++ b/km003c-lib/src/message.rs
@@ -8,6 +8,7 @@ use crate::packet::{
     Attribute, AttributeSet, CtrlHeader, DataHeader, LogicalPacket, PacketType, RawPacket, StreamingAuthHeader,
 };
 use crate::pd::{PdEventStream, PdStatus, PdStatusRaw};
+use crate::settings::Settings;
 use bytes::Bytes;
 use num_enum::FromPrimitive;
 use zerocopy::{FromBytes, IntoBytes};
@@ -24,6 +25,7 @@ pub enum PayloadData {
     AdcQueueRaw(AdcQueueRawData),
     PdStatus(PdStatus),
     PdEvents(PdEventStream),
+    Settings(Settings),
     LogMetadata(LogMetadataResponse),
     Unknown { attribute: Attribute, data: Vec<u8> },
 }
@@ -129,6 +131,17 @@ impl Packet {
         }
     }
 
+    /// Get the read-only settings payload, if present.
+    pub fn get_settings(&self) -> Option<&Settings> {
+        match self {
+            Self::DataResponse { payloads } => payloads.iter().find_map(|payload| match payload {
+                PayloadData::Settings(settings) => Some(settings),
+                _ => None,
+            }),
+            _ => None,
+        }
+    }
+
     /// Get the response to a LogMetadata request, if present.
     pub fn get_log_metadata(&self) -> Option<&LogMetadataResponse> {
         match self {
@@ -148,6 +161,7 @@ impl Packet {
                 PayloadData::AdcQueue(_) => attr == Attribute::AdcQueue,
                 PayloadData::AdcQueueRaw(_) => attr == Attribute::AdcQueue,
                 PayloadData::PdStatus(_) | PayloadData::PdEvents(_) => attr == Attribute::PdPacket,
+                PayloadData::Settings(_) => attr == Attribute::Settings,
                 PayloadData::LogMetadata(_) => attr == Attribute::LogMetadata,
                 PayloadData::Unknown { attribute, .. } => *attribute == attr,
             }),
@@ -268,6 +282,7 @@ impl Packet {
                                 PayloadData::PdEvents(pd_events)
                             }
                         }
+                        Attribute::Settings => PayloadData::Settings(Settings::from_bytes(lp.payload.as_ref())?),
                         Attribute::LogMetadata => {
                             if lp.payload.is_empty() {
                                 PayloadData::LogMetadata(LogMetadataResponse::Empty)
@@ -347,6 +362,15 @@ impl Packet {
                         PayloadData::PdEvents(_) => {
                             return Err(KMError::UnsupportedSerialization {
                                 packet: "PdEventStream",
+                            });
+                        }
+                        PayloadData::Settings(settings) => {
+                            logical_packets.push(LogicalPacket {
+                                attribute: Attribute::Settings,
+                                next: false,
+                                chunk: 0,
+                                size: crate::settings::SETTINGS_SIZE as u16,
+                                payload: settings.to_bytes().to_vec(),
                             });
                         }
                         PayloadData::LogMetadata(response) => {

--- a/km003c-lib/src/settings.rs
+++ b/km003c-lib/src/settings.rs
@@ -1,0 +1,199 @@
+//! Read-only parsing for the two persisted KM003C settings blocks.
+
+use uom::si::f64::{Ratio, Time};
+use uom::si::ratio::percent;
+use uom::si::time::microsecond;
+
+use crate::error::KMError;
+
+/// Size of the first independently checksummed settings block.
+pub const SETTINGS_A_SIZE: usize = 96;
+/// Size of the second independently checksummed settings block.
+pub const SETTINGS_B_SIZE: usize = 84;
+/// Combined payload size returned by GetData(Settings).
+pub const SETTINGS_SIZE: usize = SETTINGS_A_SIZE + SETTINGS_B_SIZE;
+
+const SETTINGS_A_CHECKSUM_OFFSET: usize = 0x5c;
+const SETTINGS_B_OFFSET: usize = SETTINGS_A_SIZE;
+const SETTINGS_B_CHECKSUM_OFFSET: usize = SETTINGS_B_OFFSET + 0x50;
+const SAMPLE_INTERVAL_OFFSET: usize = 0x08;
+const DEVICE_NAME_OFFSET: usize = 0x70;
+const DEVICE_NAME_END: usize = 0xb0;
+
+const LANGUAGE_SELECTION_MASK: u32 = 1;
+const UNCALIBRATED_MASK: u32 = 1 << 2;
+const BRIGHTNESS_SHIFT: u32 = 3;
+const BRIGHTNESS_MASK: u32 = 0x7f << BRIGHTNESS_SHIFT;
+const ORIENTATION_MASK: u32 = 0b11;
+const MTOOLS_DEVICE_MODE_SHIFT: u32 = 2;
+const MTOOLS_DEVICE_MODE_MASK: u32 = 0b11 << MTOOLS_DEVICE_MODE_SHIFT;
+const SELECTED_MAIN_PAGE_SHIFT: u32 = 6;
+const SELECTED_MAIN_PAGE_MASK: u32 = 0x0f << SELECTED_MAIN_PAGE_SHIFT;
+
+/// Lossless, read-only representation of a GetData(Settings) payload.
+///
+/// Unknown fields remain available through [`Self::settings_a_raw`] and
+/// [`Self::settings_b_raw`]. Only fields whose meanings are corroborated by
+/// KM003C V1.9.9 firmware consumers have semantic accessors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Settings {
+    bytes: [u8; SETTINGS_SIZE],
+}
+
+impl Settings {
+    /// Parse both settings blocks and validate their independent CRC-32 values.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, KMError> {
+        let bytes: [u8; SETTINGS_SIZE] = bytes.try_into().map_err(|_| {
+            KMError::InvalidPacket(format!(
+                "Settings payload must be exactly {SETTINGS_SIZE} bytes, got {}",
+                bytes.len()
+            ))
+        })?;
+
+        validate_checksum("Settings-A", &bytes[..SETTINGS_A_SIZE], SETTINGS_A_CHECKSUM_OFFSET)?;
+        validate_checksum(
+            "Settings-B",
+            &bytes[SETTINGS_B_OFFSET..],
+            SETTINGS_B_CHECKSUM_OFFSET - SETTINGS_B_OFFSET,
+        )?;
+
+        Ok(Self { bytes })
+    }
+
+    /// Serialize the exact captured settings payload, including unknown fields.
+    pub fn to_bytes(&self) -> [u8; SETTINGS_SIZE] {
+        self.bytes
+    }
+
+    /// Return the complete first persisted settings block.
+    pub fn settings_a_raw(&self) -> &[u8] {
+        &self.bytes[..SETTINGS_A_SIZE]
+    }
+
+    /// Return the complete second persisted settings block.
+    pub fn settings_b_raw(&self) -> &[u8] {
+        &self.bytes[SETTINGS_B_OFFSET..]
+    }
+
+    /// Raw settings-A flags, including fields whose meanings remain unknown.
+    pub fn settings_a_flags(&self) -> u32 {
+        read_u32(&self.bytes, 0)
+    }
+
+    /// Raw settings-B flags, including fields whose meanings remain unknown.
+    pub fn settings_b_flags(&self) -> u32 {
+        read_u32(&self.bytes, SETTINGS_B_OFFSET)
+    }
+
+    /// Firmware language-table selection, encoded as 0 or 1.
+    ///
+    /// The mapping from these indices to a particular language is not yet
+    /// independently confirmed, so this accessor deliberately returns the
+    /// stored index rather than guessing an enum variant.
+    pub fn language_selection(&self) -> u8 {
+        (self.settings_a_flags() & LANGUAGE_SELECTION_MASK) as u8
+    }
+
+    /// Whether firmware marks the device as requiring calibration.
+    pub fn is_uncalibrated(&self) -> bool {
+        self.settings_a_flags() & UNCALIBRATED_MASK != 0
+    }
+
+    /// Display brightness as applied by firmware, in percent.
+    ///
+    /// The stored field is seven bits wide; firmware clamps values above 100.
+    pub fn brightness(&self) -> Ratio {
+        let percent_value = (((self.settings_a_flags() & BRIGHTNESS_MASK) >> BRIGHTNESS_SHIFT) as u8).min(100);
+        Ratio::new::<percent>(f64::from(percent_value))
+    }
+
+    /// ADC sample interval stored in the settings block.
+    pub fn sample_interval(&self) -> Time {
+        Time::new::<microsecond>(f64::from(read_u16(&self.bytes, SAMPLE_INTERVAL_OFFSET)))
+    }
+
+    /// Display orientation index stored by firmware, in the range 0..=3.
+    pub fn screen_orientation(&self) -> u8 {
+        (self.settings_b_flags() & ORIENTATION_MASK) as u8
+    }
+
+    /// Mtools device-mode index stored by firmware, in the range 0..=3.
+    pub fn mtools_device_mode(&self) -> u8 {
+        ((self.settings_b_flags() & MTOOLS_DEVICE_MODE_MASK) >> MTOOLS_DEVICE_MODE_SHIFT) as u8
+    }
+
+    /// Persisted main-page index, in the range 0..=15.
+    pub fn selected_main_page(&self) -> u8 {
+        ((self.settings_b_flags() & SELECTED_MAIN_PAGE_MASK) >> SELECTED_MAIN_PAGE_SHIFT) as u8
+    }
+
+    /// Raw 64-byte device-name field, including trailing zero padding.
+    pub fn device_name_raw(&self) -> &[u8] {
+        &self.bytes[DEVICE_NAME_OFFSET..DEVICE_NAME_END]
+    }
+
+    /// UTF-8 device name when the stored bytes are valid UTF-8.
+    pub fn device_name(&self) -> Option<&str> {
+        let raw = self.device_name_raw();
+        let length = raw.iter().position(|byte| *byte == 0).unwrap_or(raw.len());
+        std::str::from_utf8(&raw[..length]).ok()
+    }
+
+    /// Stored CRC-32 for the first settings block.
+    pub fn settings_a_checksum(&self) -> u32 {
+        read_u32(&self.bytes, SETTINGS_A_CHECKSUM_OFFSET)
+    }
+
+    /// Stored CRC-32 for the second settings block.
+    pub fn settings_b_checksum(&self) -> u32 {
+        read_u32(&self.bytes, SETTINGS_B_CHECKSUM_OFFSET)
+    }
+}
+
+fn validate_checksum(name: &str, block: &[u8], checksum_offset: usize) -> Result<(), KMError> {
+    let stored = read_u32(block, checksum_offset);
+    let calculated = crc32fast::hash(&block[..checksum_offset]);
+    if stored != calculated {
+        return Err(KMError::InvalidPacket(format!(
+            "{name} checksum mismatch: stored 0x{stored:08x}, calculated 0x{calculated:08x}"
+        )));
+    }
+    Ok(())
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes(bytes[offset..offset + 2].try_into().expect("validated settings offset"))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes(bytes[offset..offset + 4].try_into().expect("validated settings offset"))
+}
+
+#[cfg(feature = "python")]
+impl<'py> pyo3::IntoPyObject<'py> for Settings {
+    type Target = pyo3::types::PyDict;
+    type Output = pyo3::Bound<'py, Self::Target>;
+    type Error = pyo3::PyErr;
+
+    fn into_pyobject(self, py: pyo3::Python<'py>) -> Result<Self::Output, Self::Error> {
+        use pyo3::types::PyDictMethods;
+        use uom::si::ratio::percent;
+        use uom::si::time::microsecond;
+
+        let dict = pyo3::types::PyDict::new(py);
+        dict.set_item("settings_a_flags", self.settings_a_flags())?;
+        dict.set_item("settings_b_flags", self.settings_b_flags())?;
+        dict.set_item("language_selection", self.language_selection())?;
+        dict.set_item("uncalibrated", self.is_uncalibrated())?;
+        dict.set_item("brightness_percent", self.brightness().get::<percent>())?;
+        dict.set_item("sample_interval_us", self.sample_interval().get::<microsecond>())?;
+        dict.set_item("screen_orientation", self.screen_orientation())?;
+        dict.set_item("mtools_device_mode", self.mtools_device_mode())?;
+        dict.set_item("selected_main_page", self.selected_main_page())?;
+        dict.set_item("device_name", self.device_name())?;
+        dict.set_item("settings_a_checksum", self.settings_a_checksum())?;
+        dict.set_item("settings_b_checksum", self.settings_b_checksum())?;
+        dict.set_item("raw", hex::encode(self.to_bytes()))?;
+        Ok(dict)
+    }
+}

--- a/km003c-lib/src/settings.rs
+++ b/km003c-lib/src/settings.rs
@@ -20,15 +20,40 @@ const SAMPLE_INTERVAL_OFFSET: usize = 0x08;
 const DEVICE_NAME_OFFSET: usize = 0x70;
 const DEVICE_NAME_END: usize = 0xb0;
 
-const LANGUAGE_SELECTION_MASK: u32 = 1;
-const UNCALIBRATED_MASK: u32 = 1 << 2;
-const BRIGHTNESS_SHIFT: u32 = 3;
-const BRIGHTNESS_MASK: u32 = 0x7f << BRIGHTNESS_SHIFT;
-const ORIENTATION_MASK: u32 = 0b11;
-const MTOOLS_DEVICE_MODE_SHIFT: u32 = 2;
-const MTOOLS_DEVICE_MODE_MASK: u32 = 0b11 << MTOOLS_DEVICE_MODE_SHIFT;
-const SELECTED_MAIN_PAGE_SHIFT: u32 = 6;
-const SELECTED_MAIN_PAGE_MASK: u32 = 0x0f << SELECTED_MAIN_PAGE_SHIFT;
+mod fields {
+    #![allow(
+        dead_code,
+        reason = "modular-bitfield generates constructors for these read-only views"
+    )]
+
+    use modular_bitfield::prelude::*;
+
+    #[bitfield(bytes = 4)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(super) struct SettingsAFields {
+        pub language_selection: B1,
+        #[skip]
+        __: B1,
+        pub uncalibrated: bool,
+        pub brightness_percent: B7,
+        #[skip]
+        __: B22,
+    }
+
+    #[bitfield(bytes = 4)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(super) struct SettingsBFields {
+        pub screen_orientation: B2,
+        pub mtools_device_mode: B2,
+        #[skip]
+        __: B2,
+        pub selected_main_page: B4,
+        #[skip]
+        __: B22,
+    }
+}
+
+use fields::{SettingsAFields, SettingsBFields};
 
 /// Lossless, read-only representation of a GetData(Settings) payload.
 ///
@@ -85,25 +110,33 @@ impl Settings {
         read_u32(&self.bytes, SETTINGS_B_OFFSET)
     }
 
+    fn settings_a_fields(&self) -> SettingsAFields {
+        SettingsAFields::from_bytes(self.settings_a_flags().to_le_bytes())
+    }
+
+    fn settings_b_fields(&self) -> SettingsBFields {
+        SettingsBFields::from_bytes(self.settings_b_flags().to_le_bytes())
+    }
+
     /// Firmware language-table selection, encoded as 0 or 1.
     ///
     /// The mapping from these indices to a particular language is not yet
     /// independently confirmed, so this accessor deliberately returns the
     /// stored index rather than guessing an enum variant.
     pub fn language_selection(&self) -> u8 {
-        (self.settings_a_flags() & LANGUAGE_SELECTION_MASK) as u8
+        self.settings_a_fields().language_selection()
     }
 
     /// Whether firmware marks the device as requiring calibration.
     pub fn is_uncalibrated(&self) -> bool {
-        self.settings_a_flags() & UNCALIBRATED_MASK != 0
+        self.settings_a_fields().uncalibrated()
     }
 
     /// Display brightness as applied by firmware, in percent.
     ///
     /// The stored field is seven bits wide; firmware clamps values above 100.
     pub fn brightness(&self) -> Ratio {
-        let percent_value = (((self.settings_a_flags() & BRIGHTNESS_MASK) >> BRIGHTNESS_SHIFT) as u8).min(100);
+        let percent_value = self.settings_a_fields().brightness_percent().min(100);
         Ratio::new::<percent>(f64::from(percent_value))
     }
 
@@ -114,17 +147,17 @@ impl Settings {
 
     /// Display orientation index stored by firmware, in the range 0..=3.
     pub fn screen_orientation(&self) -> u8 {
-        (self.settings_b_flags() & ORIENTATION_MASK) as u8
+        self.settings_b_fields().screen_orientation()
     }
 
     /// Mtools device-mode index stored by firmware, in the range 0..=3.
     pub fn mtools_device_mode(&self) -> u8 {
-        ((self.settings_b_flags() & MTOOLS_DEVICE_MODE_MASK) >> MTOOLS_DEVICE_MODE_SHIFT) as u8
+        self.settings_b_fields().mtools_device_mode()
     }
 
     /// Persisted main-page index, in the range 0..=15.
     pub fn selected_main_page(&self) -> u8 {
-        ((self.settings_b_flags() & SELECTED_MAIN_PAGE_MASK) >> SELECTED_MAIN_PAGE_SHIFT) as u8
+        self.settings_b_fields().selected_main_page()
     }
 
     /// Raw 64-byte device-name field, including trailing zero padding.

--- a/km003c-lib/tests/settings_tests.rs
+++ b/km003c-lib/tests/settings_tests.rs
@@ -1,0 +1,65 @@
+use bytes::Bytes;
+use km003c_lib::uom::si::ratio::percent;
+use km003c_lib::uom::si::time::microsecond;
+use km003c_lib::{Packet, PayloadData, RawPacket, Settings};
+
+fn captured_settings() -> Vec<u8> {
+    hex::decode(concat!(
+        "610150f800000000102741ff00000000",
+        "fffffffffffffffffffffffffaffffff",
+        "fafffffffafffffffafffffffaffffff",
+        "ed4a0f00ed4a0f00ed4a0f00ed4a0f00",
+        "ed4a0f00ed4a0f00ed4a0f00ed4a0f00",
+        "ed4a0f00ed4a0f005e000000268bb83a",
+        "43000000000000000000000000000000",
+        "504f5745522d5a000000000000000000",
+        "00000000000000000000000000000000",
+        "00000000000000000000000000000000",
+        "00000000000000000000000000000000",
+        "207d05d2"
+    ))
+    .unwrap()
+}
+
+#[test]
+fn parses_confirmed_fields_from_captured_settings() {
+    let captured = captured_settings();
+    let settings = Settings::from_bytes(&captured).unwrap();
+
+    assert_eq!(settings.settings_a_flags(), 0xf850_0161);
+    assert_eq!(settings.language_selection(), 1);
+    assert!(!settings.is_uncalibrated());
+    assert_eq!(settings.brightness().get::<percent>(), 44.0);
+    assert_eq!(settings.sample_interval().get::<microsecond>(), 10_000.0);
+
+    assert_eq!(settings.settings_b_flags(), 0x43);
+    assert_eq!(settings.screen_orientation(), 3);
+    assert_eq!(settings.mtools_device_mode(), 0);
+    assert_eq!(settings.selected_main_page(), 1);
+    assert_eq!(settings.device_name(), Some("POWER-Z"));
+    assert_eq!(settings.to_bytes().as_slice(), captured);
+}
+
+#[test]
+fn settings_semantic_packet_round_trips_losslessly() {
+    let settings = Settings::from_bytes(&captured_settings()).unwrap();
+    let raw = Packet::DataResponse {
+        payloads: vec![PayloadData::Settings(settings.clone())],
+    }
+    .to_raw_packet(7)
+    .unwrap();
+    let reparsed = Packet::try_from(RawPacket::try_from(Bytes::from(raw)).unwrap()).unwrap();
+
+    assert_eq!(reparsed.get_settings(), Some(&settings));
+}
+
+#[test]
+fn rejects_corrupted_settings_checksums() {
+    let mut settings_a_corrupted = captured_settings();
+    settings_a_corrupted[0x08] ^= 1;
+    assert!(Settings::from_bytes(&settings_a_corrupted).is_err());
+
+    let mut settings_b_corrupted = captured_settings();
+    settings_b_corrupted[0x70] ^= 1;
+    assert!(Settings::from_bytes(&settings_b_corrupted).is_err());
+}


### PR DESCRIPTION
## What changed

- add a lossless `Settings` value object for the 96-byte settings-A and 84-byte settings-B blocks
- validate each block's independent CRC-32 before exposing semantic data
- parse GetData(Settings) into `PayloadData::Settings` and support exact semantic packet round-trips
- add `KM003C::request_settings()` and `Packet::get_settings()`
- expose only confirmed read-only fields: language index, calibration-required state, brightness as `uom::Ratio`, sample interval as `uom::Time`, orientation index, Mtools mode, selected page, and device name
- preserve every unknown field and both stored checksums through raw block accessors
- expose the same confirmed values to Python as a dictionary
- add a runnable read-only example and update project documentation

No settings command, setter, or device-memory write is added.

## Why

Firmware V1.9.9 analysis now identifies a small subset of Settings semantics, but many fields remain unknown. Returning the entire payload as `Unknown` wastes the confirmed structure; naming every field would overstate the evidence. This PR keeps parsing lossless while adding semantic access only where firmware consumers and captures agree.

## Validation

Capture-backed tests use the Settings response from `orig_adc_1000hz.6`, frame 392:

- both block checksums are validated
- confirmed offsets and bitfields are asserted
- corrupt settings-A and settings-B data are rejected
- semantic parse/serialize is byte-for-byte lossless

A connected firmware 1.9.9 device also returned two valid blocks and parsed as:

- device name `POWER-Z`
- language index 1
- calibrated
- brightness 25%
- sample interval 10000 us
- orientation 3, Mtools mode 0, selected page 1

Automated checks:

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`