### PR TITLE
Add typed PD state traces and fix response parsing

### DIFF
--- a/km003c-cli/src/bin/pd_trace.rs
+++ b/km003c-cli/src/bin/pd_trace.rs
@@ -1,0 +1,88 @@
+use std::error::Error;
+use std::time::Duration;
+
+use clap::Parser;
+use km003c_lib::uom::si::time::second;
+use km003c_lib::{DeviceConfig, KM003C, PdTraceProtocolEvent, PdTraceStateEvent};
+
+/// Drain and display the KM003C firmware's internal USB PD trace queues.
+#[derive(Debug, Parser)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// Number of trace requests to make.
+    #[arg(short, long, default_value_t = 10)]
+    polls: usize,
+
+    /// Delay between trace requests.
+    #[arg(short, long, default_value_t = 1000)]
+    interval_ms: u64,
+
+    /// Show raw USB traffic.
+    #[arg(short, long)]
+    verbose: bool,
+
+    /// Skip USB reset.
+    #[arg(long, default_value_t = cfg!(target_os = "macos"))]
+    no_reset: bool,
+
+    /// Force USB reset even when --no-reset is the platform default.
+    #[arg(long)]
+    reset: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
+    tracing_subscriber::fmt()
+        .with_max_level(if args.verbose {
+            tracing::Level::TRACE
+        } else {
+            tracing::Level::WARN
+        })
+        .init();
+
+    let mut config = DeviceConfig::vendor();
+    if args.no_reset && !args.reset {
+        config = config.skip_reset();
+    }
+    let mut device = KM003C::new(config).await?;
+
+    for poll in 0..args.polls {
+        let trace = device.request_pd_trace().await?;
+        println!(
+            "poll {}: {} state events, {} protocol events",
+            poll + 1,
+            trace.state_events.len(),
+            trace.protocol_events.len()
+        );
+        print_state_events(&trace.state_events);
+        print_protocol_events(&trace.protocol_events);
+
+        if poll + 1 < args.polls {
+            tokio::time::sleep(Duration::from_millis(args.interval_ms)).await;
+        }
+    }
+
+    Ok(())
+}
+
+fn print_state_events(events: &[PdTraceStateEvent]) {
+    for event in events {
+        println!(
+            "  state    {:?} (0x{:02x}) uptime={:.0}s",
+            event.state,
+            u8::from(event.state),
+            event.timestamp.get::<second>()
+        );
+    }
+}
+
+fn print_protocol_events(events: &[PdTraceProtocolEvent]) {
+    for event in events {
+        println!(
+            "  protocol code=0x{:02x} uptime={:.0}s",
+            event.code,
+            event.timestamp.get::<second>()
+        );
+    }
+}

--- a/km003c-lib/src/device.rs
+++ b/km003c-lib/src/device.rs
@@ -848,6 +848,15 @@ impl KM003C {
             .ok_or_else(|| KMError::Protocol("No Settings data in response".to_string()))
     }
 
+    /// Request and drain the internal USB PD state-machine trace queues.
+    pub async fn request_pd_trace(&mut self) -> Result<crate::pd_trace::PdTrace, KMError> {
+        let packet = self.request_data(AttributeSet::single(Attribute::PdTrace)).await?;
+        packet
+            .get_pd_trace()
+            .cloned()
+            .ok_or_else(|| KMError::Protocol("No PD trace data in response".to_string()))
+    }
+
     /// Request metadata for the offline log currently selected on the device.
     ///
     /// Returns an empty vector when no offline log is available.

--- a/km003c-lib/src/lib.rs
+++ b/km003c-lib/src/lib.rs
@@ -10,6 +10,7 @@ pub mod packet;
 pub mod pd;
 #[cfg(feature = "usbpd")]
 pub mod pd_decode;
+pub mod pd_trace;
 pub mod settings;
 
 #[cfg(feature = "python")]
@@ -32,6 +33,7 @@ pub use pd::{PdEvent, PdEventData, PdEventStream, PdStatus};
 pub use pd_decode::{
     DecodedPdEvent, DecodedPdMessage, PdChunkState, PdChunkStatus, PdDecodeError, PdDecodeFailure, PdSessionDecoder,
 };
+pub use pd_trace::{PdTrace, PdTraceProtocolEvent, PdTraceStateEvent, PdTypeCState};
 pub use settings::Settings;
 pub use uom;
 #[cfg(feature = "usbpd")]

--- a/km003c-lib/src/message.rs
+++ b/km003c-lib/src/message.rs
@@ -8,6 +8,7 @@ use crate::packet::{
     Attribute, AttributeSet, CtrlHeader, DataHeader, LogicalPacket, PacketType, RawPacket, StreamingAuthHeader,
 };
 use crate::pd::{PdEventStream, PdStatus, PdStatusRaw};
+use crate::pd_trace::PdTrace;
 use crate::settings::Settings;
 use bytes::Bytes;
 use num_enum::FromPrimitive;
@@ -25,6 +26,7 @@ pub enum PayloadData {
     AdcQueueRaw(AdcQueueRawData),
     PdStatus(PdStatus),
     PdEvents(PdEventStream),
+    PdTrace(PdTrace),
     Settings(Settings),
     LogMetadata(LogMetadataResponse),
     Unknown { attribute: Attribute, data: Vec<u8> },
@@ -131,6 +133,17 @@ impl Packet {
         }
     }
 
+    /// Get the internal PD state-machine trace, if present.
+    pub fn get_pd_trace(&self) -> Option<&PdTrace> {
+        match self {
+            Self::DataResponse { payloads } => payloads.iter().find_map(|payload| match payload {
+                PayloadData::PdTrace(trace) => Some(trace),
+                _ => None,
+            }),
+            _ => None,
+        }
+    }
+
     /// Get the read-only settings payload, if present.
     pub fn get_settings(&self) -> Option<&Settings> {
         match self {
@@ -161,6 +174,7 @@ impl Packet {
                 PayloadData::AdcQueue(_) => attr == Attribute::AdcQueue,
                 PayloadData::AdcQueueRaw(_) => attr == Attribute::AdcQueue,
                 PayloadData::PdStatus(_) | PayloadData::PdEvents(_) => attr == Attribute::PdPacket,
+                PayloadData::PdTrace(_) => attr == Attribute::PdTrace,
                 PayloadData::Settings(_) => attr == Attribute::Settings,
                 PayloadData::LogMetadata(_) => attr == Attribute::LogMetadata,
                 PayloadData::Unknown { attribute, .. } => *attribute == attr,
@@ -282,6 +296,7 @@ impl Packet {
                                 PayloadData::PdEvents(pd_events)
                             }
                         }
+                        Attribute::PdTrace => PayloadData::PdTrace(PdTrace::from_bytes(&lp.payload)?),
                         Attribute::Settings => PayloadData::Settings(Settings::from_bytes(lp.payload.as_ref())?),
                         Attribute::LogMetadata => {
                             if lp.payload.is_empty() {
@@ -362,6 +377,15 @@ impl Packet {
                         PayloadData::PdEvents(_) => {
                             return Err(KMError::UnsupportedSerialization {
                                 packet: "PdEventStream",
+                            });
+                        }
+                        PayloadData::PdTrace(trace) => {
+                            logical_packets.push(LogicalPacket {
+                                attribute: Attribute::PdTrace,
+                                next: false,
+                                chunk: 0,
+                                size: 0,
+                                payload: trace.to_bytes()?,
                             });
                         }
                         PayloadData::Settings(settings) => {

--- a/km003c-lib/src/packet.rs
+++ b/km003c-lib/src/packet.rs
@@ -128,6 +128,8 @@ pub enum Attribute {
     /// PD protocol data. Response is either 12-byte PdStatus (measurements only)
     /// or longer PdEventStream (12-byte preamble + PD wire events).
     PdPacket = 0x10,
+    /// Internal USB PD state-machine trace queues.
+    PdTrace = 0x20,
 
     /// Offline recording metadata.
     LogMetadata = 0x200,
@@ -445,12 +447,16 @@ impl TryFrom<Bytes> for RawPacket {
                     let has_next = ext.next();
                     let attribute = Attribute::from_primitive(ext.attribute());
                     // AdcQueue uses chunk as its sample count and size as bytes per sample.
-                    let payload_size = ext.size() as usize
-                        * if attribute == Attribute::AdcQueue {
-                            ext.chunk() as usize
-                        } else {
-                            1
-                        };
+                    let payload_size = if attribute == Attribute::PdTrace {
+                        crate::pd_trace::payload_size(&payload)?
+                    } else {
+                        ext.size() as usize
+                            * if attribute == Attribute::AdcQueue {
+                                ext.chunk() as usize
+                            } else {
+                                1
+                            }
+                    };
 
                     // For AdcQueue, the size field indicates sample size (20 bytes),
                     // but the actual payload contains multiple samples.

--- a/km003c-lib/src/packet.rs
+++ b/km003c-lib/src/packet.rs
@@ -405,9 +405,11 @@ impl TryFrom<Bytes> for RawPacket {
 
             // Only PutData packets have chained logical packets with extended headers
             if packet_type == PacketType::PutData {
-                // Check for empty PutData (obj_count_words == 0)
-                if header.obj_count_words() == 0 || payload.is_empty() {
-                    // Valid empty response - device has no data
+                // The firmware's top-level count encoding can be zero even
+                // when a valid logical packet follows (for example, a
+                // 15-byte PdTrace response). Only the actual absence of bytes
+                // means that PutData has no logical packets.
+                if payload.is_empty() {
                     return Ok(RawPacket::Data {
                         header,
                         logical_packets: vec![],

--- a/km003c-lib/src/pd_trace.rs
+++ b/km003c-lib/src/pd_trace.rs
@@ -1,0 +1,269 @@
+//! USB PD state-machine trace data exposed through attribute `0x0020`.
+
+use num_enum::{FromPrimitive, IntoPrimitive};
+use uom::si::f64::Time;
+use uom::si::time::second;
+
+use crate::error::KMError;
+
+const TRACE_RECORD_SIZE: usize = 5;
+const MAX_QUEUE_BYTES: usize = 200;
+
+/// Type-C state codes embedded in the KM003C V1.9.9 firmware.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, IntoPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[repr(u8)]
+pub enum PdTypeCState {
+    Disabled = 0x00,
+    DelayUnattached = 0x01,
+    AttachedResistance = 0x02,
+    TryResistance = 0x03,
+    AttachedDebSource = 0x04,
+    UnattachedDebSource = 0x05,
+    AttachWaitDebSource = 0x06,
+    TryDebSource = 0x07,
+    AttachedSource = 0x08,
+    UnattachedSource = 0x09,
+    AttachWaitSource = 0x0a,
+    TryWaitSource = 0x0b,
+    TrySource = 0x0c,
+    DebugAccessorySource = 0x0d,
+    AttachedCable = 0x0e,
+    IllegalCable = 0x0f,
+    AttachWaitCable = 0x10,
+    AttachWaitMonitorDefective = 0x11,
+    AttachedLightningPlug = 0x12,
+    AttachWaitLightningPlug = 0x13,
+    AttachedDebSink = 0x14,
+    AttachWaitDebSink = 0x15,
+    TryWaitDebSink = 0x16,
+    AttachedSink = 0x17,
+    AttachWaitSink = 0x18,
+    TryWaitSink = 0x19,
+    TrySink = 0x1a,
+    DebugAccessorySink = 0x1b,
+    AttachedMonitor = 0x1c,
+    AttachWaitMonitor = 0x1d,
+    CableCross = 0x1e,
+    CablePlugShortCircuit = 0x1f,
+    ErrorRecovery = 0x20,
+    PoweredAccessory = 0x21,
+    UnsupportedAccessory = 0x22,
+    AudioAccessory = 0x23,
+    AttachWaitAccessory = 0x24,
+    #[num_enum(catch_all)]
+    Unknown(u8),
+}
+
+/// One Type-C state transition with a one-second-resolution uptime timestamp.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "python", pyo3::pyclass(skip_from_py_object))]
+pub struct PdTraceStateEvent {
+    pub state: PdTypeCState,
+    /// Device uptime when the transition was recorded.
+    pub timestamp: Time,
+}
+
+/// One raw protocol/message event with a one-second-resolution timestamp.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "python", pyo3::pyclass(skip_from_py_object))]
+pub struct PdTraceProtocolEvent {
+    /// Firmware event code. Names remain raw until the complete enumeration is
+    /// independently confirmed.
+    pub code: u8,
+    /// Device uptime when the event was recorded.
+    pub timestamp: Time,
+}
+
+/// Two trace queues returned by the KM003C USB PD state machine.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "python", pyo3::pyclass(skip_from_py_object))]
+pub struct PdTrace {
+    /// High-level USB PD state transitions.
+    pub state_events: Vec<PdTraceStateEvent>,
+    /// Protocol and message-processing events.
+    pub protocol_events: Vec<PdTraceProtocolEvent>,
+}
+
+impl PdTrace {
+    /// Parse the two length-prefixed event queues.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, KMError> {
+        let (state_records, offset) = parse_queue(bytes, 0, "state")?;
+        let (protocol_records, offset) = parse_queue(bytes, offset, "protocol")?;
+
+        if offset != bytes.len() {
+            return Err(KMError::InvalidPacket(format!(
+                "PD trace has {} trailing bytes",
+                bytes.len() - offset
+            )));
+        }
+
+        Ok(Self {
+            state_events: state_records
+                .into_iter()
+                .map(|record| PdTraceStateEvent {
+                    state: PdTypeCState::from_primitive(record.code),
+                    timestamp: record.timestamp,
+                })
+                .collect(),
+            protocol_events: protocol_records
+                .into_iter()
+                .map(|record| PdTraceProtocolEvent {
+                    code: record.code,
+                    timestamp: record.timestamp,
+                })
+                .collect(),
+        })
+    }
+
+    /// Serialize the trace using the firmware queue layout.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, KMError> {
+        let mut bytes = Vec::new();
+        append_queue(
+            &mut bytes,
+            self.state_events.iter().map(|event| TraceRecord {
+                code: event.state.into(),
+                timestamp: event.timestamp,
+            }),
+            "state",
+        )?;
+        append_queue(
+            &mut bytes,
+            self.protocol_events.iter().map(|event| TraceRecord {
+                code: event.code,
+                timestamp: event.timestamp,
+            }),
+            "protocol",
+        )?;
+        Ok(bytes)
+    }
+}
+
+pub(crate) fn payload_size(bytes: &[u8]) -> Result<usize, KMError> {
+    let state_size = queue_size(bytes, 0, "state")?;
+    let protocol_offset = 1 + state_size;
+    let protocol_size = queue_size(bytes, protocol_offset, "protocol")?;
+    Ok(protocol_offset + 1 + protocol_size)
+}
+
+fn queue_size(bytes: &[u8], offset: usize, name: &str) -> Result<usize, KMError> {
+    let size = usize::from(*bytes.get(offset).ok_or_else(|| {
+        KMError::InvalidPacket(format!(
+            "PD trace is missing the {name} queue length at offset {offset}"
+        ))
+    })?);
+
+    if size > MAX_QUEUE_BYTES {
+        return Err(KMError::InvalidPacket(format!(
+            "PD trace {name} queue is too large: {size} bytes, maximum is {MAX_QUEUE_BYTES}"
+        )));
+    }
+    if !size.is_multiple_of(TRACE_RECORD_SIZE) {
+        return Err(KMError::InvalidPacket(format!(
+            "PD trace {name} queue length must be a multiple of {TRACE_RECORD_SIZE}, got {size}"
+        )));
+    }
+    if bytes.len().saturating_sub(offset + 1) < size {
+        return Err(KMError::InvalidPacket(format!(
+            "PD trace {name} queue is truncated: expected {size} bytes, got {}",
+            bytes.len().saturating_sub(offset + 1)
+        )));
+    }
+
+    Ok(size)
+}
+
+#[derive(Clone, Copy)]
+struct TraceRecord {
+    code: u8,
+    timestamp: Time,
+}
+
+fn parse_queue(bytes: &[u8], offset: usize, name: &str) -> Result<(Vec<TraceRecord>, usize), KMError> {
+    let size = queue_size(bytes, offset, name)?;
+    let start = offset + 1;
+    let end = start + size;
+    let events = bytes[start..end]
+        .chunks_exact(TRACE_RECORD_SIZE)
+        .map(|record| TraceRecord {
+            code: record[0],
+            timestamp: Time::new::<second>(f64::from(u32::from_le_bytes([
+                record[1], record[2], record[3], record[4],
+            ]))),
+        })
+        .collect();
+    Ok((events, end))
+}
+
+fn append_queue(
+    bytes: &mut Vec<u8>,
+    events: impl ExactSizeIterator<Item = TraceRecord>,
+    name: &str,
+) -> Result<(), KMError> {
+    let size = events
+        .len()
+        .checked_mul(TRACE_RECORD_SIZE)
+        .ok_or_else(|| KMError::InvalidPacket(format!("PD trace {name} queue length overflow")))?;
+    if size > MAX_QUEUE_BYTES {
+        return Err(KMError::InvalidPacket(format!(
+            "PD trace {name} queue is too large: {size} bytes, maximum is {MAX_QUEUE_BYTES}"
+        )));
+    }
+
+    bytes.push(size as u8);
+    for event in events {
+        bytes.push(event.code);
+        bytes.extend_from_slice(&(event.timestamp.get::<second>() as u32).to_le_bytes());
+    }
+    Ok(())
+}
+
+#[cfg(feature = "python")]
+#[pyo3::pymethods]
+impl PdTraceStateEvent {
+    #[getter]
+    fn state_code(&self) -> u8 {
+        self.state.into()
+    }
+
+    #[getter]
+    fn state_name(&self) -> String {
+        format!("{:?}", self.state)
+    }
+
+    #[getter]
+    fn timestamp_seconds(&self) -> f64 {
+        self.timestamp.get::<second>()
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyo3::pymethods]
+impl PdTraceProtocolEvent {
+    #[getter]
+    fn code(&self) -> u8 {
+        self.code
+    }
+
+    #[getter]
+    fn timestamp_seconds(&self) -> f64 {
+        self.timestamp.get::<second>()
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyo3::pymethods]
+impl PdTrace {
+    #[getter]
+    fn state_events(&self) -> Vec<PdTraceStateEvent> {
+        self.state_events.clone()
+    }
+
+    #[getter]
+    fn protocol_events(&self) -> Vec<PdTraceProtocolEvent> {
+        self.protocol_events.clone()
+    }
+}

--- a/km003c-lib/tests/pd_trace_tests.rs
+++ b/km003c-lib/tests/pd_trace_tests.rs
@@ -7,6 +7,11 @@ fn trace_payload() -> Vec<u8> {
     vec![10, 1, 100, 0, 0, 0, 4, 105, 0, 0, 0, 5, 0x82, 110, 0, 0, 0]
 }
 
+fn parse_recorded_trace(frame: &str) -> PdTrace {
+    let raw = RawPacket::try_from(Bytes::from(hex::decode(frame).unwrap())).unwrap();
+    Packet::try_from(raw).unwrap().get_pd_trace().unwrap().clone()
+}
+
 #[test]
 fn parses_two_firmware_trace_queues() {
     let trace = PdTrace::from_bytes(&trace_payload()).unwrap();
@@ -77,4 +82,82 @@ fn semantic_trace_round_trips_through_a_put_data_packet() {
     let reparsed = Packet::try_from(RawPacket::try_from(Bytes::from(raw)).unwrap()).unwrap();
 
     assert_eq!(reparsed.get_pd_trace(), Some(&trace));
+}
+
+#[test]
+fn parses_recorded_single_event_response_with_zero_top_level_count() {
+    // Captured from KM003C V1.9.9 while a Pixel 8 Pro was connected. The
+    // top-level obj_count_words field decodes to zero even though one complete
+    // PdTrace logical packet follows.
+    let trace = parse_recorded_trace("410a020020000000000582b9000000");
+
+    assert!(trace.state_events.is_empty());
+    assert_eq!(trace.protocol_events.len(), 1);
+    assert_eq!(trace.protocol_events[0].code, 0x82);
+    assert_eq!(trace.protocol_events[0].timestamp.get::<second>(), 185.0);
+}
+
+#[test]
+fn parses_recorded_phone_disconnect_response() {
+    let trace = parse_recorded_trace("410682002000000005020b01000005000b010000");
+
+    assert_eq!(trace.state_events.len(), 1);
+    assert_eq!(trace.state_events[0].state, PdTypeCState::AttachedResistance);
+    assert_eq!(trace.state_events[0].timestamp.get::<second>(), 267.0);
+    assert_eq!(trace.protocol_events.len(), 1);
+    assert_eq!(trace.protocol_events[0].code, 0x00);
+    assert_eq!(trace.protocol_events[0].timestamp.get::<second>(), 267.0);
+}
+
+#[test]
+fn parses_recorded_phone_connect_response_with_a_full_protocol_queue() {
+    let trace = parse_recorded_trace(concat!(
+        "4106020d200000000f12ab00000005ab00000007ab000000c876ab00000077",
+        "ab00000082ab00000078ab00000082ab00000082ac00000082ac00000082",
+        "ac00000082ac00000082ac00000082ac00000082ac00000082ac00000052",
+        "ac00000078ac00000082ac00000082ac00000082ac00000082ac00000082",
+        "ac00000082ad00000082ae00000082ae00000082ae00000082ae00000082",
+        "b000000082b000000082b000000082b000000082b000000082b000000082",
+        "b000000082b000000082b000000082b100000082b100000082b100000082",
+        "b100000082b100000082b1000000"
+    ));
+
+    assert_eq!(trace.state_events.len(), 3);
+    assert_eq!(trace.state_events[0].state, PdTypeCState::AttachedLightningPlug);
+    assert_eq!(trace.state_events[1].state, PdTypeCState::UnattachedDebSource);
+    assert_eq!(trace.state_events[2].state, PdTypeCState::TryDebSource);
+    assert_eq!(trace.protocol_events.len(), 40);
+    assert_eq!(trace.protocol_events[0].code, 0x76);
+    assert_eq!(trace.protocol_events[1].code, 0x77);
+    assert_eq!(trace.protocol_events[2].code, 0x82);
+    assert_eq!(trace.protocol_events.last().unwrap().timestamp.get::<second>(), 177.0);
+}
+
+#[test]
+fn splits_recorded_zero_sized_trace_before_a_chained_attribute() {
+    // Captured from KM003C V1.9.9 with the phone disconnected. PdTrace reports
+    // an extended-header size of zero, contains two empty queue prefixes, and
+    // is followed by attribute 0x0080 in the same PutData response.
+    let raw = RawPacket::try_from(Bytes::from(
+        hex::decode("4106820020800000000080000002eefe050000000000").unwrap(),
+    ))
+    .unwrap();
+
+    let RawPacket::Data { logical_packets, .. } = &raw else {
+        panic!("expected a data packet");
+    };
+    assert_eq!(logical_packets.len(), 2);
+    assert_eq!(logical_packets[0].attribute, Attribute::PdTrace);
+    assert_eq!(logical_packets[0].payload.as_slice(), &[0, 0]);
+    assert_eq!(logical_packets[1].attribute, Attribute::Unknown(0x80));
+    assert_eq!(
+        logical_packets[1].payload.as_slice(),
+        &[0xee, 0xfe, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00]
+    );
+
+    let packet = Packet::try_from(raw).unwrap();
+    let trace = packet.get_pd_trace().unwrap();
+    assert!(trace.state_events.is_empty());
+    assert!(trace.protocol_events.is_empty());
+    assert!(packet.has_payload(Attribute::Unknown(0x80)));
 }

--- a/km003c-lib/tests/pd_trace_tests.rs
+++ b/km003c-lib/tests/pd_trace_tests.rs
@@ -1,0 +1,80 @@
+use bytes::Bytes;
+use km003c_lib::packet::{DataHeader, ExtendedHeader, PacketType};
+use km003c_lib::uom::si::time::second;
+use km003c_lib::{Attribute, Packet, PayloadData, PdTrace, PdTypeCState, RawPacket};
+
+fn trace_payload() -> Vec<u8> {
+    vec![10, 1, 100, 0, 0, 0, 4, 105, 0, 0, 0, 5, 0x82, 110, 0, 0, 0]
+}
+
+#[test]
+fn parses_two_firmware_trace_queues() {
+    let trace = PdTrace::from_bytes(&trace_payload()).unwrap();
+
+    assert_eq!(trace.state_events.len(), 2);
+    assert_eq!(trace.state_events[0].state, PdTypeCState::DelayUnattached);
+    assert_eq!(trace.state_events[0].timestamp.get::<second>(), 100.0);
+    assert_eq!(trace.state_events[1].state, PdTypeCState::AttachedDebSource);
+    assert_eq!(trace.protocol_events.len(), 1);
+    assert_eq!(trace.protocol_events[0].code, 0x82);
+    assert_eq!(trace.protocol_events[0].timestamp.get::<second>(), 110.0);
+    assert_eq!(trace.to_bytes().unwrap(), trace_payload());
+}
+
+#[test]
+fn rejects_malformed_trace_queues() {
+    assert!(PdTrace::from_bytes(&[]).is_err());
+    assert!(PdTrace::from_bytes(&[4, 0, 0, 0, 0, 0]).is_err());
+    assert!(PdTrace::from_bytes(&[5, 1, 0, 0, 0, 0]).is_err());
+
+    let oversized = vec![205; 207];
+    assert!(PdTrace::from_bytes(&oversized).is_err());
+}
+
+#[test]
+fn splits_zero_sized_trace_before_a_chained_payload() {
+    let mut bytes = DataHeader::new()
+        .with_packet_type(PacketType::PutData.into())
+        .with_id(7)
+        .with_obj_count_words(1)
+        .into_bytes()
+        .to_vec();
+    bytes.extend_from_slice(
+        &ExtendedHeader::new()
+            .with_attribute(Attribute::PdTrace.into())
+            .with_next(true)
+            .with_size(0)
+            .into_bytes(),
+    );
+    bytes.extend_from_slice(&trace_payload());
+    bytes.extend_from_slice(
+        &ExtendedHeader::new()
+            .with_attribute(Attribute::PdPacket.into())
+            .with_next(false)
+            .with_size(12)
+            .into_bytes(),
+    );
+    bytes.extend_from_slice(&[0; 12]);
+
+    let raw = RawPacket::try_from(Bytes::from(bytes)).unwrap();
+    let packet = Packet::try_from(raw).unwrap();
+    let Packet::DataResponse { payloads } = packet else {
+        panic!("expected data response");
+    };
+
+    assert!(matches!(payloads[0], PayloadData::PdTrace(_)));
+    assert!(matches!(payloads[1], PayloadData::PdStatus(_)));
+}
+
+#[test]
+fn semantic_trace_round_trips_through_a_put_data_packet() {
+    let trace = PdTrace::from_bytes(&trace_payload()).unwrap();
+    let raw = Packet::DataResponse {
+        payloads: vec![PayloadData::PdTrace(trace.clone())],
+    }
+    .to_raw_packet(3)
+    .unwrap();
+    let reparsed = Packet::try_from(RawPacket::try_from(Bytes::from(raw)).unwrap()).unwrap();
+
+    assert_eq!(reparsed.get_pd_trace(), Some(&trace));
+}


### PR DESCRIPTION
## Summary

- decode the V1.9.9 firmware PD trace queues and expose named Type-C states
- add `KM003C::request_pd_trace` and a `pd_trace` CLI
- derive zero-sized trace boundaries correctly in chained responses
- accept populated PutData frames whose top-level count decodes to zero

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- tested against a KM003C running V1.9.9 with a Pixel 8 Pro: empty, connect, active/full-queue, disconnect, and chained-attribute responses