### PR TITLE
Type confirmed PD trace events

### DIFF
--- a/km003c-cli/src/bin/pd_trace.rs
+++ b/km003c-cli/src/bin/pd_trace.rs
@@ -80,8 +80,9 @@ fn print_state_events(events: &[PdTraceStateEvent]) {
 fn print_protocol_events(events: &[PdTraceProtocolEvent]) {
     for event in events {
         println!(
-            "  protocol code=0x{:02x} uptime={:.0}s",
-            event.code,
+            "  protocol {:?} (0x{:02x}) uptime={:.0}s",
+            event.kind,
+            u8::from(event.kind),
             event.timestamp.get::<second>()
         );
     }

--- a/km003c-lib/src/lib.rs
+++ b/km003c-lib/src/lib.rs
@@ -33,7 +33,7 @@ pub use pd::{PdEvent, PdEventData, PdEventStream, PdStatus};
 pub use pd_decode::{
     DecodedPdEvent, DecodedPdMessage, PdChunkState, PdChunkStatus, PdDecodeError, PdDecodeFailure, PdSessionDecoder,
 };
-pub use pd_trace::{PdTrace, PdTraceProtocolEvent, PdTraceStateEvent, PdTypeCState};
+pub use pd_trace::{PdProtocolTraceEventKind, PdTrace, PdTraceProtocolEvent, PdTraceStateEvent, PdTypeCState};
 pub use settings::Settings;
 pub use uom;
 #[cfg(feature = "usbpd")]

--- a/km003c-lib/src/pd_trace.rs
+++ b/km003c-lib/src/pd_trace.rs
@@ -55,6 +55,26 @@ pub enum PdTypeCState {
     Unknown(u8),
 }
 
+/// Firmware protocol-engine trace codes confirmed in KM003C V1.9.9.
+///
+/// Most values in this queue are internal protocol-engine states whose names
+/// are not present in the firmware. The two non-state markers below are
+/// emitted directly by the receive path and have independently recoverable
+/// semantics. All other values are preserved losslessly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, IntoPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[repr(u8)]
+pub enum PdProtocolTraceEventKind {
+    /// The protocol engine was reset while the Type-C state detached.
+    Disabled = 0x00,
+    /// A received PD message or extended-message chunk was processed.
+    ReceivedMessage = 0x82,
+    /// The receive path queued a request for the next extended-message chunk.
+    ExtendedChunkRequest = 0x83,
+    #[num_enum(catch_all)]
+    Unknown(u8),
+}
+
 /// One Type-C state transition with a one-second-resolution uptime timestamp.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -70,9 +90,8 @@ pub struct PdTraceStateEvent {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "python", pyo3::pyclass(skip_from_py_object))]
 pub struct PdTraceProtocolEvent {
-    /// Firmware event code. Names remain raw until the complete enumeration is
-    /// independently confirmed.
-    pub code: u8,
+    /// Typed firmware marker, or a losslessly preserved protocol-engine state.
+    pub kind: PdProtocolTraceEventKind,
     /// Device uptime when the event was recorded.
     pub timestamp: Time,
 }
@@ -112,7 +131,7 @@ impl PdTrace {
             protocol_events: protocol_records
                 .into_iter()
                 .map(|record| PdTraceProtocolEvent {
-                    code: record.code,
+                    kind: PdProtocolTraceEventKind::from_primitive(record.code),
                     timestamp: record.timestamp,
                 })
                 .collect(),
@@ -133,7 +152,7 @@ impl PdTrace {
         append_queue(
             &mut bytes,
             self.protocol_events.iter().map(|event| TraceRecord {
-                code: event.code,
+                code: event.kind.into(),
                 timestamp: event.timestamp,
             }),
             "protocol",
@@ -245,7 +264,12 @@ impl PdTraceStateEvent {
 impl PdTraceProtocolEvent {
     #[getter]
     fn code(&self) -> u8 {
-        self.code
+        self.kind.into()
+    }
+
+    #[getter]
+    fn event_name(&self) -> String {
+        format!("{:?}", self.kind)
     }
 
     #[getter]

--- a/km003c-lib/tests/pd_trace_tests.rs
+++ b/km003c-lib/tests/pd_trace_tests.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use km003c_lib::packet::{DataHeader, ExtendedHeader, PacketType};
 use km003c_lib::uom::si::time::second;
-use km003c_lib::{Attribute, Packet, PayloadData, PdTrace, PdTypeCState, RawPacket};
+use km003c_lib::{Attribute, Packet, PayloadData, PdProtocolTraceEventKind, PdTrace, PdTypeCState, RawPacket};
 
 fn trace_payload() -> Vec<u8> {
     vec![10, 1, 100, 0, 0, 0, 4, 105, 0, 0, 0, 5, 0x82, 110, 0, 0, 0]
@@ -21,9 +21,23 @@ fn parses_two_firmware_trace_queues() {
     assert_eq!(trace.state_events[0].timestamp.get::<second>(), 100.0);
     assert_eq!(trace.state_events[1].state, PdTypeCState::AttachedDebSource);
     assert_eq!(trace.protocol_events.len(), 1);
-    assert_eq!(trace.protocol_events[0].code, 0x82);
+    assert_eq!(trace.protocol_events[0].kind, PdProtocolTraceEventKind::ReceivedMessage);
     assert_eq!(trace.protocol_events[0].timestamp.get::<second>(), 110.0);
     assert_eq!(trace.to_bytes().unwrap(), trace_payload());
+}
+
+#[test]
+fn types_confirmed_protocol_markers_and_preserves_unknown_states() {
+    let payload = vec![0, 15, 0x82, 1, 0, 0, 0, 0x83, 2, 0, 0, 0, 0x52, 3, 0, 0, 0];
+    let trace = PdTrace::from_bytes(&payload).unwrap();
+
+    assert_eq!(trace.protocol_events[0].kind, PdProtocolTraceEventKind::ReceivedMessage);
+    assert_eq!(
+        trace.protocol_events[1].kind,
+        PdProtocolTraceEventKind::ExtendedChunkRequest
+    );
+    assert_eq!(trace.protocol_events[2].kind, PdProtocolTraceEventKind::Unknown(0x52));
+    assert_eq!(trace.to_bytes().unwrap(), payload);
 }
 
 #[test]
@@ -93,7 +107,7 @@ fn parses_recorded_single_event_response_with_zero_top_level_count() {
 
     assert!(trace.state_events.is_empty());
     assert_eq!(trace.protocol_events.len(), 1);
-    assert_eq!(trace.protocol_events[0].code, 0x82);
+    assert_eq!(trace.protocol_events[0].kind, PdProtocolTraceEventKind::ReceivedMessage);
     assert_eq!(trace.protocol_events[0].timestamp.get::<second>(), 185.0);
 }
 
@@ -105,7 +119,7 @@ fn parses_recorded_phone_disconnect_response() {
     assert_eq!(trace.state_events[0].state, PdTypeCState::AttachedResistance);
     assert_eq!(trace.state_events[0].timestamp.get::<second>(), 267.0);
     assert_eq!(trace.protocol_events.len(), 1);
-    assert_eq!(trace.protocol_events[0].code, 0x00);
+    assert_eq!(trace.protocol_events[0].kind, PdProtocolTraceEventKind::Disabled);
     assert_eq!(trace.protocol_events[0].timestamp.get::<second>(), 267.0);
 }
 
@@ -127,9 +141,9 @@ fn parses_recorded_phone_connect_response_with_a_full_protocol_queue() {
     assert_eq!(trace.state_events[1].state, PdTypeCState::UnattachedDebSource);
     assert_eq!(trace.state_events[2].state, PdTypeCState::TryDebSource);
     assert_eq!(trace.protocol_events.len(), 40);
-    assert_eq!(trace.protocol_events[0].code, 0x76);
-    assert_eq!(trace.protocol_events[1].code, 0x77);
-    assert_eq!(trace.protocol_events[2].code, 0x82);
+    assert_eq!(trace.protocol_events[0].kind, PdProtocolTraceEventKind::Unknown(0x76));
+    assert_eq!(trace.protocol_events[1].kind, PdProtocolTraceEventKind::Unknown(0x77));
+    assert_eq!(trace.protocol_events[2].kind, PdProtocolTraceEventKind::ReceivedMessage);
     assert_eq!(trace.protocol_events.last().unwrap().timestamp.get::<second>(), 177.0);
 }
 


### PR DESCRIPTION
## Summary

- model the firmware-confirmed protocol trace codes as `PdProtocolTraceEventKind`
- identify `0x00` as the detached protocol reset state, `0x82` as received-message processing, and `0x83` as an extended chunk request
- preserve all unnamed protocol-engine states losslessly through `Unknown(u8)`
- show typed names in the CLI and Python event API

## Evidence

The mappings come from KM003C V1.9.9 firmware control flow. `0x82` is also present in the recorded Pixel 8 Pro hardware trace; the `0x00` disconnect response is capture-backed. `0x83` is firmware-confirmed and intentionally documented as awaiting a hardware trace.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`