### PR TITLE
Add firmware PD trace to the egui timeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
  "accesskit",
  "accesskit_consumer 0.36.0",
  "atspi-common",
- "phf",
+ "phf 0.13.1",
  "serde",
  "zvariant",
 ]
@@ -113,8 +113,8 @@ dependencies = [
  "accesskit_consumer 0.35.0",
  "hashbrown 0.16.1",
  "static_assertions",
- "windows",
- "windows-core",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -145,7 +145,7 @@ checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -159,6 +159,30 @@ dependencies = [
  "once_cell",
  "version_check",
  "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -252,6 +276,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +303,22 @@ dependencies = [
  "windows-sys 0.60.2",
  "x11rb",
 ]
+
+[[package]]
+name = "argminmax"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f13d10a41ac8d2ec79ee34178d61e6f47a29c2edfe7ef1721c7383b0359e65"
+dependencies = [
+ "half",
+ "num-traits",
+]
+
+[[package]]
+name = "array-init-cursor"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed51fe0f224d1d4ea768be38c51f9f831dee9d05c163c11fba0b8c44387b1fc3"
 
 [[package]]
 name = "arrayref"
@@ -413,6 +462,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +498,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.0",
+]
+
+[[package]]
+name = "atoi_simd"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ad17c7c205c2c28b527b9845eeb91cf1b4d008b438f98ce0e628227a822758e"
+dependencies = [
+ "debug_unsafe",
 ]
 
 [[package]]
@@ -479,6 +559,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +610,32 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block2"
@@ -534,6 +666,33 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+
+[[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -579,6 +738,9 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "calloop"
@@ -632,6 +794,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,8 +842,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "rand_core",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -681,7 +874,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -771,6 +964,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +986,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
@@ -837,6 +1051,15 @@ checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -854,6 +1077,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +1124,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "crypto-common"
@@ -881,6 +1151,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +1179,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.1",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -936,6 +1224,12 @@ name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecolor"
@@ -1172,6 +1466,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "ethnum"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
+
+[[package]]
 name = "euclid"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1500,18 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
@@ -1242,7 +1554,14 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1302,10 +1621,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1338,6 +1703,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+
+[[package]]
 name = "futures-task"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,11 +1720,25 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1363,7 +1748,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1373,9 +1771,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1385,9 +1785,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1416,6 +1818,12 @@ dependencies = [
  "smallvec",
  "vello_common",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
@@ -1506,7 +1914,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.19",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -1539,14 +1947,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
+ "serde",
  "zerocopy",
 ]
 
@@ -1577,6 +2006,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1589,6 +2020,9 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "rayon",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1635,12 +2069,150 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1768,6 +2340,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1788,6 +2362,12 @@ dependencies = [
  "core-foundation-sys",
  "mach2",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1824,7 +2404,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.19",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1926,6 +2506,8 @@ dependencies = [
  "eframe",
  "egui_plot",
  "km003c-lib",
+ "polars",
+ "rfd",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1943,9 +2525,9 @@ dependencies = [
  "num_enum",
  "nusb",
  "pyo3",
- "rand",
+ "rand 0.10.2",
  "serde",
- "strum_macros",
+ "strum_macros 0.28.0",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -1985,7 +2567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2050,6 +2632,31 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "mach2"
@@ -2199,6 +2806,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "now"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89e9874397a1f0a52fc1f197a8effd9735223cb2390e9dcc83ac6cd02923d0"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2851,17 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2347,6 +2983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.1",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2465,6 +3102,16 @@ dependencies = [
  "bitflags 2.13.1",
  "block2 0.6.2",
  "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -2609,6 +3256,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.10.2",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +3312,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "orbclient"
@@ -2684,7 +3383,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2708,12 +3407,21 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
 ]
 
@@ -2724,7 +3432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2734,10 +3442,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2799,6 +3516,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "planus"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3daf8e3d4b712abe1d690838f6e29fb76b76ea19589c4afa39ec30e12f62af71"
+dependencies = [
+ "array-init-cursor",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2809,6 +3536,615 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polars"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f1f122456ec136102033b13f71905b7c3f01e526642679c86aace9f9cdefde"
+dependencies = [
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "polars-arrow",
+ "polars-buffer",
+ "polars-compute",
+ "polars-core",
+ "polars-error",
+ "polars-io",
+ "polars-lazy",
+ "polars-ops",
+ "polars-parquet",
+ "polars-sql",
+ "polars-utils",
+ "version_check",
+]
+
+[[package]]
+name = "polars-arrow"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87d4892d5cc6461bb4a184d18e6fa03a5d316ee1d6de06a33dfa08d479fbc2db"
+dependencies = [
+ "atoi_simd",
+ "bitflags 2.13.1",
+ "bytemuck",
+ "bytes",
+ "chrono",
+ "chrono-tz",
+ "dyn-clone",
+ "either",
+ "ethnum",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "half",
+ "hashbrown 0.16.1",
+ "itoa",
+ "lz4",
+ "num-traits",
+ "polars-arrow-format",
+ "polars-buffer",
+ "polars-error",
+ "polars-schema",
+ "polars-utils",
+ "serde",
+ "simdutf8",
+ "streaming-iterator",
+ "strum_macros 0.27.2",
+ "version_check",
+ "zstd",
+]
+
+[[package]]
+name = "polars-arrow-format"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a556ac0ee744e61e167f34c1eb0013ce740e0ee6cd8c158b2ec0b518f10e6675"
+dependencies = [
+ "planus",
+ "serde",
+]
+
+[[package]]
+name = "polars-async"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e87f836190486f500b28347436985cc0af29b7a514e53f98840d396ce4d5f5"
+dependencies = [
+ "atomic-waker",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "parking_lot",
+ "pin-project-lite",
+ "polars-config",
+ "polars-error",
+ "polars-utils",
+ "rand 0.9.5",
+ "slotmap",
+ "tokio",
+]
+
+[[package]]
+name = "polars-buffer"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e481eeaf33c544ac0dd71a2e375553ca2fdae47b3472a96eaccb6eb43218783d"
+dependencies = [
+ "bytemuck",
+ "either",
+ "polars-utils",
+ "serde",
+ "version_check",
+]
+
+[[package]]
+name = "polars-compute"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55d41642a9ee887ac394c5a310af3256fa8340a86cde2cb624c515aa963461c"
+dependencies = [
+ "atoi_simd",
+ "bytemuck",
+ "chrono",
+ "either",
+ "fast-float2",
+ "hashbrown 0.16.1",
+ "itoa",
+ "num-traits",
+ "polars-arrow",
+ "polars-buffer",
+ "polars-error",
+ "polars-utils",
+ "rand 0.9.5",
+ "serde",
+ "strength_reduce",
+ "strum_macros 0.27.2",
+ "version_check",
+ "zmij",
+]
+
+[[package]]
+name = "polars-config"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65af861341b00eac73bcb65423fb5cc3d2322526d6b7561a0ddf094947c38033"
+dependencies = [
+ "polars-error",
+ "serde",
+]
+
+[[package]]
+name = "polars-core"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5924fc46306054bae78f9d35ea5e404cf185baa7f170eb55a16ff95191069c"
+dependencies = [
+ "bitflags 2.13.1",
+ "boxcar",
+ "bytemuck",
+ "chrono",
+ "chrono-tz",
+ "either",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "itoa",
+ "num-traits",
+ "polars-arrow",
+ "polars-async",
+ "polars-buffer",
+ "polars-compute",
+ "polars-config",
+ "polars-dtype",
+ "polars-error",
+ "polars-row",
+ "polars-schema",
+ "polars-utils",
+ "rand 0.9.5",
+ "rand_distr",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum_macros 0.27.2",
+ "tokio",
+ "uuid",
+ "version_check",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "polars-dtype"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b65a750bb99ea66be90c8a7e336f6f3a87427a0f7f89d2a40adae98314e9b27"
+dependencies = [
+ "boxcar",
+ "hashbrown 0.16.1",
+ "polars-arrow",
+ "polars-error",
+ "polars-utils",
+ "serde",
+ "uuid",
+]
+
+[[package]]
+name = "polars-error"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e49a75e3406b9b5b4e5ff177877fe0de766e9688fbdb263a7b25f293dc47d61a"
+dependencies = [
+ "object_store",
+ "parking_lot",
+ "polars-arrow-format",
+ "regex",
+ "signal-hook",
+ "simdutf8",
+]
+
+[[package]]
+name = "polars-expr"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e21fdd37e8d9ef109f13d3454baffa0a57041cf60069123b8a2bd846c8ad0205"
+dependencies = [
+ "bitflags 2.13.1",
+ "hashbrown 0.16.1",
+ "num-traits",
+ "polars-arrow",
+ "polars-buffer",
+ "polars-compute",
+ "polars-core",
+ "polars-io",
+ "polars-ops",
+ "polars-plan",
+ "polars-row",
+ "polars-time",
+ "polars-utils",
+ "rand 0.9.5",
+ "rayon",
+ "recursive",
+ "regex",
+ "version_check",
+]
+
+[[package]]
+name = "polars-io"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6363a1c44a65fe8d73cce7fe4d77c9b6fea3a0da44007012e755e5b4e65aa078"
+dependencies = [
+ "async-trait",
+ "atoi_simd",
+ "blake3",
+ "bytes",
+ "fast-float2",
+ "fastrand",
+ "fs4",
+ "futures",
+ "glob",
+ "hashbrown 0.16.1",
+ "home",
+ "itoa",
+ "memchr",
+ "memmap2",
+ "num-traits",
+ "object_store",
+ "parking_lot",
+ "percent-encoding",
+ "polars-arrow",
+ "polars-buffer",
+ "polars-compute",
+ "polars-config",
+ "polars-core",
+ "polars-error",
+ "polars-parquet",
+ "polars-schema",
+ "polars-utils",
+ "rand 0.9.5",
+ "rayon",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "tokio",
+ "zmij",
+]
+
+[[package]]
+name = "polars-lazy"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809d9590232a37d638337629c18279af97bdb0d17c3d8b2b6bb186e903e8bd5e"
+dependencies = [
+ "bitflags 2.13.1",
+ "chrono",
+ "either",
+ "memchr",
+ "polars-arrow",
+ "polars-buffer",
+ "polars-compute",
+ "polars-config",
+ "polars-core",
+ "polars-expr",
+ "polars-io",
+ "polars-mem-engine",
+ "polars-ops",
+ "polars-plan",
+ "polars-stream",
+ "polars-time",
+ "polars-utils",
+ "rayon",
+ "version_check",
+]
+
+[[package]]
+name = "polars-mem-engine"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55c6b7d162c506bc8eee82b065fa0399ebcd20b8f08675a534f3d360904ba38"
+dependencies = [
+ "memmap2",
+ "polars-arrow",
+ "polars-core",
+ "polars-error",
+ "polars-expr",
+ "polars-io",
+ "polars-ops",
+ "polars-plan",
+ "polars-time",
+ "polars-utils",
+ "rayon",
+ "recursive",
+]
+
+[[package]]
+name = "polars-ooc"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3eea0b386837b760a97ec9c92df99cbc10f94885cae060fd7100f9b794163"
+dependencies = [
+ "async-trait",
+ "boxcar",
+ "libc",
+ "polars-async",
+ "polars-config",
+ "polars-core",
+ "polars-io",
+ "polars-utils",
+ "thread_local",
+ "tokio",
+]
+
+[[package]]
+name = "polars-ops"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb146490a717ac5ae4ff3a22a5adf3ebae79361f187b1f550f9e24783d7ad765"
+dependencies = [
+ "argminmax",
+ "base64",
+ "bytemuck",
+ "chrono",
+ "chrono-tz",
+ "either",
+ "hashbrown 0.16.1",
+ "hex",
+ "indexmap",
+ "libm",
+ "memchr",
+ "num-traits",
+ "polars-arrow",
+ "polars-buffer",
+ "polars-compute",
+ "polars-core",
+ "polars-error",
+ "polars-schema",
+ "polars-utils",
+ "rayon",
+ "regex",
+ "regex-syntax",
+ "strum_macros 0.27.2",
+ "unicode-normalization",
+ "unicode-reverse",
+ "version_check",
+]
+
+[[package]]
+name = "polars-parquet"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6b79ba2103c00cbb9c5dd4459ffff1d8ce15286c7a6d376a04c711df20d8b7"
+dependencies = [
+ "async-stream",
+ "base64",
+ "brotli",
+ "bytemuck",
+ "ethnum",
+ "flate2",
+ "futures",
+ "hashbrown 0.16.1",
+ "lz4",
+ "num-traits",
+ "polars-arrow",
+ "polars-buffer",
+ "polars-compute",
+ "polars-config",
+ "polars-error",
+ "polars-parquet-format",
+ "polars-utils",
+ "regex",
+ "serde",
+ "simdutf8",
+ "snap",
+ "streaming-decompression",
+ "zstd",
+]
+
+[[package]]
+name = "polars-parquet-format"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c025243dcfe8dbc57e94d9f82eb3bef10b565ab180d5b99bed87fd8aea319ce1"
+dependencies = [
+ "async-trait",
+ "futures",
+]
+
+[[package]]
+name = "polars-plan"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f5ccc230515adb10762a8c7b0df03fd88f3328deb5b60e9b1eeb2eceef4d344"
+dependencies = [
+ "bitflags 2.13.1",
+ "blake3",
+ "bytemuck",
+ "bytes",
+ "chrono",
+ "chrono-tz",
+ "either",
+ "futures",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "memmap2",
+ "num-traits",
+ "percent-encoding",
+ "polars-arrow",
+ "polars-buffer",
+ "polars-compute",
+ "polars-config",
+ "polars-core",
+ "polars-error",
+ "polars-io",
+ "polars-ops",
+ "polars-parquet",
+ "polars-time",
+ "polars-utils",
+ "rayon",
+ "recursive",
+ "regex",
+ "sha2",
+ "slotmap",
+ "strum_macros 0.27.2",
+ "tokio",
+ "version_check",
+]
+
+[[package]]
+name = "polars-row"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4e3254450024078e10c919ecd3b467bdcfdd5cf386c2ca6eedec89bd4771d2"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "polars-arrow",
+ "polars-buffer",
+ "polars-compute",
+ "polars-dtype",
+ "polars-error",
+ "polars-utils",
+]
+
+[[package]]
+name = "polars-schema"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8a0de8951d02576fd0cdcecd9c605a6b6364d3105b7469b8d7874ea34eea2f"
+dependencies = [
+ "indexmap",
+ "polars-error",
+ "polars-utils",
+ "serde",
+ "version_check",
+]
+
+[[package]]
+name = "polars-sql"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b282a6164927eb12774b66b071b773a1573173ae53758e8d4df50389ff06efa2"
+dependencies = [
+ "bitflags 2.13.1",
+ "hex",
+ "polars-core",
+ "polars-error",
+ "polars-lazy",
+ "polars-ops",
+ "polars-plan",
+ "polars-time",
+ "polars-utils",
+ "regex",
+ "serde",
+ "sqlparser",
+]
+
+[[package]]
+name = "polars-stream"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa8ff4ee21799898579595a0ef2fb728d0a9cac3d061835fb7f7f6dd854734a"
+dependencies = [
+ "async-channel",
+ "async-trait",
+ "bitflags 2.13.1",
+ "bytes",
+ "chrono-tz",
+ "crossbeam-channel",
+ "crossbeam-queue",
+ "futures",
+ "memchr",
+ "num-traits",
+ "parking_lot",
+ "percent-encoding",
+ "polars-arrow",
+ "polars-async",
+ "polars-buffer",
+ "polars-compute",
+ "polars-config",
+ "polars-core",
+ "polars-error",
+ "polars-expr",
+ "polars-io",
+ "polars-mem-engine",
+ "polars-ooc",
+ "polars-ops",
+ "polars-parquet",
+ "polars-plan",
+ "polars-time",
+ "polars-utils",
+ "rayon",
+ "recursive",
+ "slotmap",
+ "tokio",
+ "uuid",
+ "version_check",
+]
+
+[[package]]
+name = "polars-time"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1063fe074c4212a54917be604377c6e6bfbc8b6c942a5c57be214e4ccaaafdf"
+dependencies = [
+ "atoi_simd",
+ "bytemuck",
+ "chrono",
+ "chrono-tz",
+ "now",
+ "num-traits",
+ "polars-arrow",
+ "polars-compute",
+ "polars-core",
+ "polars-error",
+ "polars-ops",
+ "polars-utils",
+ "rayon",
+ "regex",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "polars-utils"
+version = "0.54.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590b0a94aa8f97992d52f1198600ecc1c1f7cfa03c1b31cae057143455804ac0"
+dependencies = [
+ "argminmax",
+ "bincode",
+ "bytemuck",
+ "bytes",
+ "compact_str",
+ "either",
+ "flate2",
+ "foldhash 0.2.0",
+ "futures",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "libc",
+ "memmap2",
+ "num-derive",
+ "num-traits",
+ "polars-config",
+ "polars-error",
+ "rand 0.9.5",
+ "raw-cpuid",
+ "rayon",
+ "regex",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "serde_stacker",
+ "slotmap",
+ "stacker",
+ "sysinfo",
+ "tokio",
+ "uuid",
+ "version_check",
 ]
 
 [[package]]
@@ -2865,6 +4201,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2914,6 +4259,16 @@ name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
 
 [[package]]
 name = "pxfm"
@@ -2991,6 +4346,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3016,13 +4428,42 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3032,10 +4473,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.5",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "range-alloc"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.1",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -3056,6 +4525,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "read-fonts"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3063,6 +4552,26 @@ checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
  "font-types",
+]
+
+[[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3093,10 +4602,141 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "libc",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "percent-encoding",
+ "pollster",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "web-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -3146,10 +4786,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3158,6 +4851,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3183,6 +4885,29 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit 0.19.2",
  "tiny-skia",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3252,6 +4977,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_stacker"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4936375d50c4be7eff22293a9344f8e46f323ed2b3c243e52f89138d9bb0f4a"
+dependencies = [
+ "serde",
+ "serde_core",
+ "stacker",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3265,6 +5024,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -3408,6 +5177,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "snap"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
+
+[[package]]
 name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3427,16 +5202,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlparser"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "505aa16b045c4c1375bf5f125cce3813d0176325bfe9ffc4a903f423de7774ff"
+dependencies = [
+ "log",
+ "recursive",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028e551d5e270b31b9f3ea271778d9d827148d4287a5d96167b6bb9787f5cc38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-decompression"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6cc3b19bfb128a8ad11026086e31d3ce9ad23f8ea37354b31383a187c44cf3"
+dependencies = [
+ "fallible-streaming-iterator",
+]
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strict-num"
@@ -3452,6 +5283,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "strum_macros"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
@@ -3461,6 +5304,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -3485,6 +5334,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,6 +5351,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3622,6 +5494,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3647,6 +5534,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -3678,6 +5588,51 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -3738,6 +5693,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3782,6 +5743,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-reverse"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6f4888ebc23094adfb574fdca9fdc891826287a6397d2cd28802ffd6f20c76"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,6 +5771,18 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "uom"
@@ -3856,6 +5847,7 @@ version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3902,6 +5894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3909,6 +5907,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -3979,6 +5986,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -4307,9 +6327,9 @@ dependencies = [
  "web-sys",
  "wgpu-naga-bridge",
  "wgpu-types",
- "windows",
- "windows-core",
- "windows-result",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4337,6 +6357,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4346,15 +6382,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
 name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4363,7 +6427,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -4374,9 +6451,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -4385,9 +6473,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -4414,9 +6502,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -4424,8 +6528,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4434,7 +6547,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4443,7 +6565,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4479,7 +6601,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4504,7 +6626,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4517,11 +6639,20 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4757,6 +6888,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
+name = "xxhash-rust"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985eec839aaf2a1270af8f4ebcf63cf9401cfd90f0902f97c28d9f104ffbde72"
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4918,6 +7055,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4951,10 +7094,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "zlib-rs"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ Command-line tools:
 
 ### `km003c-egui`
 GUI application featuring:
-- Real-time voltage/current/power plots
+- Three independently configurable real-time plots for electrical and USB-line measurements
 - AdcQueue streaming with configurable sample rates
 - Adjustable time window (2s to 5min or all data)
+- Live recording and plot-buffer export to Parquet or CSV
+- Host-integrated charge and energy with explicit missing-sample quality data
 - Device info panel with auth status
 - Connect/disconnect control
 
@@ -137,6 +139,23 @@ cargo run --bin offline-log -- download --index 0 --format csv
 ```bash
 cargo run --bin km003c-egui
 ```
+
+The GUI records the complete AdcQueue sample set, independently of which three
+measurements are currently plotted. Parquet is the default format; CSV is
+available for compatibility. Each row contains device-relative time and
+sequence information, VBUS/current/power, CC1/CC2/D+/D- voltages, and cumulative
+charge and energy. Integer electrical columns use units in their names
+(`*_uv`, `*_ua`, and `*_uw`); `charge_uah` and `energy_uwh` are floating-point
+cumulative values.
+
+Charge and energy use trapezoidal integration over the KM003C sequence clock.
+If samples are missing, the interval is retained as a linear estimate rather
+than invalidating the rest of the recording. The affected row and cumulative
+quality are exposed through `missing_samples`, `gap_duration_us`,
+`interpolated`, `cumulative_missing_samples`, and
+`cumulative_interpolated_duration_us`. The GUI reports completeness as the
+fraction of elapsed time covered by received intervals rather than estimated
+gap intervals.
 
 ## Library Usage
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,11 @@ If samples are missing, the interval is retained as a linear estimate rather
 than invalidating the rest of the recording. The affected row and cumulative
 quality are exposed through `missing_samples`, `gap_duration_us`,
 `interpolated`, `cumulative_missing_samples`, and
-`cumulative_interpolated_duration_us`. The GUI reports completeness as the
-fraction of elapsed time covered by received intervals rather than estimated
-gap intervals.
+`cumulative_interpolated_duration_us`. Duplicate, stale, and invalid-sequence
+samples are excluded from plots and integration and counted by
+`discarded_sequence_samples` and `cumulative_discarded_sequence_samples`. The
+GUI reports completeness as the fraction of elapsed time covered by received
+intervals rather than estimated gap intervals.
 
 ## Library Usage
 

--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ measurements are currently plotted. Parquet is the default format; CSV is
 available for compatibility. Each row contains device-relative time and
 sequence information, VBUS/current/power, CC1/CC2/D+/D- voltages, and cumulative
 charge and energy. Integer electrical columns use units in their names
-(`*_uv`, `*_ua`, and `*_uw`); `charge_uah` and `energy_uwh` are floating-point
-cumulative values.
+(`*_uv`, `*_ua`, and `*_uw`). Signed net accumulation is stored in
+`charge_uah` and `energy_uwh`; positive transferred totals are stored in
+`charge_throughput_uah` and `energy_throughput_uwh`.
 
 Charge and energy use trapezoidal integration over the KM003C sequence clock.
 If samples are missing, the interval is retained as a linear estimate rather

--- a/km003c-egui/Cargo.toml
+++ b/km003c-egui/Cargo.toml
@@ -17,6 +17,8 @@ path = "src/main.rs"
 km003c-lib = { workspace = true, features = ["usbpd"] }
 eframe = "0.35.0"
 egui_plot = "0.36.0"
+polars = { version = "0.54.4", default-features = false, features = ["csv", "parquet"] }
+rfd = "0.17.2"
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/km003c-egui/src/main.rs
+++ b/km003c-egui/src/main.rs
@@ -442,6 +442,7 @@ impl eframe::App for PowerMonitorApp {
 
         // Left panel with device info and controls
         egui::Panel::left("info_panel").min_size(220.0).show(ui, |ui| {
+            egui::ScrollArea::vertical().auto_shrink([false; 2]).show(ui, |ui| {
             ui.heading("Device Info");
             ui.separator();
 
@@ -687,6 +688,7 @@ impl eframe::App for PowerMonitorApp {
                         .send(UsbCommand::Connect(self.selected_rate.to_graph_rate(), self.usb_reset));
                 }
             }
+            });
 
         });
 

--- a/km003c-egui/src/main.rs
+++ b/km003c-egui/src/main.rs
@@ -1,5 +1,6 @@
 mod pd_connection;
 mod pd_decoder;
+mod pd_trace_view;
 
 use eframe::egui;
 use egui_plot::{Line, Plot, PlotPoints};
@@ -8,13 +9,14 @@ use km003c_lib::uom::si::electric_potential::volt;
 use km003c_lib::uom::si::power::watt;
 use km003c_lib::uom::si::time::second;
 use km003c_lib::{
-    AdcQueueSample, DeviceConfig, DeviceState, GraphSampleRate, KM003C,
+    AdcQueueSample, DeviceConfig, DeviceState, GraphSampleRate, KM003C, PdTrace,
     packet::{Attribute, AttributeSet},
     pd::{PdEvent, PdEventData, PdStatus},
     sequence_elapsed,
 };
 use pd_connection::PdConnectionTracker;
 use pd_decoder::{DecodedPdEntry, PdCategory, PdDecoder};
+use pd_trace_view::{PdTraceCategory, PdTraceEntry, decode_trace};
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
@@ -34,6 +36,8 @@ enum UsbMessage {
     PdEvents(Vec<PdEvent>),
     /// PD status (CC line voltages)
     PdStatusUpdate(PdStatus),
+    /// Firmware Type-C and protocol-engine trace
+    PdTrace(PdTrace),
     /// Streaming started at given rate
     StreamingStarted(GraphSampleRate),
     /// Streaming stopped
@@ -51,8 +55,41 @@ enum UsbCommand {
     Connect(GraphSampleRate, bool),
     /// Change sample rate (stops current streaming, starts with new rate)
     SetSampleRate(GraphSampleRate),
+    /// Enable or disable firmware PD trace collection
+    SetPdTraceEnabled(bool),
     /// Stop streaming and disconnect
     Disconnect,
+}
+
+enum PdTimelineEntry<'a> {
+    Protocol(&'a DecodedPdEntry),
+    FirmwareTrace(&'a PdTraceEntry),
+}
+
+impl PdTimelineEntry<'_> {
+    fn timestamp_seconds(&self) -> f64 {
+        match self {
+            Self::Protocol(entry) => entry.timestamp_seconds,
+            Self::FirmwareTrace(entry) => entry.timestamp_seconds,
+        }
+    }
+}
+
+fn pd_timeline_entries<'a>(
+    protocol_log: &'a VecDeque<DecodedPdEntry>,
+    trace_log: &'a VecDeque<PdTraceEntry>,
+    show_protocol: bool,
+    show_trace: bool,
+) -> Vec<PdTimelineEntry<'a>> {
+    let mut timeline = Vec::with_capacity(protocol_log.len() + trace_log.len());
+    if show_protocol {
+        timeline.extend(protocol_log.iter().map(PdTimelineEntry::Protocol));
+    }
+    if show_trace {
+        timeline.extend(trace_log.iter().map(PdTimelineEntry::FirmwareTrace));
+    }
+    timeline.sort_by(|left, right| left.timestamp_seconds().total_cmp(&right.timestamp_seconds()));
+    timeline
 }
 
 /// Sample rate options for the UI
@@ -185,6 +222,14 @@ struct PowerMonitorApp {
     pd_auto_scroll: bool,
     /// PD panel visible
     pd_panel_visible: bool,
+    /// Show decoded wire-protocol events in the shared timeline
+    pd_protocol_visible: bool,
+    /// Whether the USB task should drain the firmware PD trace queues
+    pd_trace_enabled: bool,
+    /// Firmware PD trace entries
+    pd_trace_log: VecDeque<PdTraceEntry>,
+    /// Max firmware PD trace entries
+    max_pd_trace_entries: usize,
     /// Whether to perform USB reset on connect
     usb_reset: bool,
 }
@@ -217,6 +262,10 @@ impl PowerMonitorApp {
             pd_connection: PdConnectionTracker::default(),
             pd_auto_scroll: true,
             pd_panel_visible: true,
+            pd_protocol_visible: true,
+            pd_trace_enabled: false,
+            pd_trace_log: VecDeque::new(),
+            max_pd_trace_entries: 2000,
             usb_reset: !cfg!(target_os = "macos"),
         }
     }
@@ -228,6 +277,9 @@ impl PowerMonitorApp {
                     self.status = format!("Connected: {}", state.model());
                     self.device_state = Some(state);
                     self.pd_connection = PdConnectionTracker::default();
+                    if self.pd_trace_enabled {
+                        let _ = self.cmd_sender.send(UsbCommand::SetPdTraceEnabled(true));
+                    }
                 }
                 UsbMessage::ConnectionFailed(err) => {
                     self.status = format!("Connection failed: {}", err);
@@ -314,6 +366,14 @@ impl PowerMonitorApp {
                     self.pd_connection.observe_status(&status, std::time::Instant::now());
                     self.pd_status = Some(status);
                 }
+                UsbMessage::PdTrace(trace) => {
+                    for entry in decode_trace(&trace) {
+                        self.pd_trace_log.push_back(entry);
+                        while self.pd_trace_log.len() > self.max_pd_trace_entries {
+                            self.pd_trace_log.pop_front();
+                        }
+                    }
+                }
                 UsbMessage::StreamingStopped => {
                     self.streaming = false;
                     self.status = "Stopped".to_string();
@@ -346,7 +406,8 @@ impl PowerMonitorApp {
 
     fn clear_pd_log(&mut self) {
         self.pd_log.clear();
-        info!("PD log cleared");
+        self.pd_trace_log.clear();
+        info!("PD timeline cleared");
     }
 }
 
@@ -503,6 +564,38 @@ impl eframe::App for PowerMonitorApp {
 
             ui.add_space(20.0);
             ui.separator();
+            ui.heading("PD Timeline");
+            ui.separator();
+
+            ui.checkbox(&mut self.pd_panel_visible, "Show PD Panel");
+            ui.label("Filters:");
+            ui.checkbox(&mut self.pd_protocol_visible, "Protocol messages");
+            let trace_changed = ui
+                .checkbox(&mut self.pd_trace_enabled, "Firmware trace")
+                .on_hover_text(
+                    "Also drains the diagnostic Type-C and protocol-engine queues reverse engineered from KM003C firmware V1.9.9",
+                )
+                .changed();
+            if trace_changed && self.device_state.is_some() {
+                let _ = self
+                    .cmd_sender
+                    .send(UsbCommand::SetPdTraceEnabled(self.pd_trace_enabled));
+            }
+
+            ui.horizontal(|ui| {
+                ui.checkbox(&mut self.pd_auto_scroll, "Auto-scroll");
+                if ui.button("Clear Timeline").clicked() {
+                    self.clear_pd_log();
+                }
+            });
+            ui.label(format!(
+                "Protocol: {}  |  Trace: {}",
+                self.pd_log.len(),
+                self.pd_trace_log.len()
+            ));
+
+            ui.add_space(20.0);
+            ui.separator();
             ui.heading("Statistics");
             ui.separator();
 
@@ -595,65 +688,79 @@ impl eframe::App for PowerMonitorApp {
                 }
             }
 
-            ui.add_space(20.0);
-            ui.separator();
-            ui.heading("PD Log");
-            ui.separator();
-
-            ui.horizontal(|ui| {
-                ui.checkbox(&mut self.pd_panel_visible, "Show PD Panel");
-            });
-
-            ui.horizontal(|ui| {
-                ui.checkbox(&mut self.pd_auto_scroll, "Auto-scroll");
-                if ui.button("Clear PD Log").clicked() {
-                    self.clear_pd_log();
-                }
-            });
-
-            ui.label(format!("PD entries: {}", self.pd_log.len()));
         });
 
-        // Bottom panel with PD log
+        // Bottom panel with the combined PD timeline
         if self.pd_panel_visible {
             egui::Panel::bottom("pd_panel")
                 .resizable(true)
                 .min_size(100.0)
                 .default_size(200.0)
                 .show(ui, |ui| {
-                    ui.heading("USB PD Protocol Log");
+                    ui.heading("USB PD Timeline");
+                    if self.pd_trace_enabled {
+                        ui.small(
+                            "[FW] timestamps have one-second resolution; same-second ordering relative to [WIRE] events is approximate.",
+                        );
+                    }
                     ui.separator();
 
                     let text_style = egui::TextStyle::Monospace;
                     let row_height = ui.text_style_height(&text_style);
+                    let timeline = pd_timeline_entries(
+                        &self.pd_log,
+                        &self.pd_trace_log,
+                        self.pd_protocol_visible,
+                        self.pd_trace_enabled,
+                    );
 
                     egui::ScrollArea::vertical()
                         .auto_shrink([false; 2])
                         .stick_to_bottom(self.pd_auto_scroll)
                         .show(ui, |ui| {
-                            for entry in &self.pd_log {
-                                let color = match entry.category {
-                                    PdCategory::Connect => egui::Color32::GREEN,
-                                    PdCategory::Disconnect => egui::Color32::RED,
-                                    PdCategory::SourceCaps => egui::Color32::from_rgb(100, 149, 237), // Cornflower blue
-                                    PdCategory::Request => egui::Color32::YELLOW,
-                                    PdCategory::Control => egui::Color32::GRAY,
-                                    PdCategory::Extended => egui::Color32::from_rgb(255, 165, 0), // Orange
-                                    PdCategory::Error => egui::Color32::from_rgb(255, 80, 80),    // Light red
-                                };
+                            for timeline_entry in timeline {
+                                match timeline_entry {
+                                    PdTimelineEntry::Protocol(entry) => {
+                                        let color = match entry.category {
+                                            PdCategory::Connect => egui::Color32::GREEN,
+                                            PdCategory::Disconnect => egui::Color32::RED,
+                                            PdCategory::SourceCaps => egui::Color32::from_rgb(100, 149, 237),
+                                            PdCategory::Request => egui::Color32::YELLOW,
+                                            PdCategory::Control => egui::Color32::GRAY,
+                                            PdCategory::Extended => egui::Color32::from_rgb(255, 165, 0),
+                                            PdCategory::Error => egui::Color32::from_rgb(255, 80, 80),
+                                        };
 
-                                ui.colored_label(
-                                    color,
-                                    egui::RichText::new(&entry.summary).monospace().size(row_height),
-                                );
-
-                                for detail in &entry.details {
-                                    ui.colored_label(
-                                        color.gamma_multiply(0.8),
-                                        egui::RichText::new(format!("  {}", detail))
-                                            .monospace()
-                                            .size(row_height),
-                                    );
+                                        ui.colored_label(
+                                            color,
+                                            egui::RichText::new(format!("[WIRE] {}", entry.summary))
+                                                .monospace()
+                                                .size(row_height),
+                                        );
+                                        for detail in &entry.details {
+                                            ui.colored_label(
+                                                color.gamma_multiply(0.8),
+                                                egui::RichText::new(format!("       {detail}"))
+                                                    .monospace()
+                                                    .size(row_height),
+                                            );
+                                        }
+                                    }
+                                    PdTimelineEntry::FirmwareTrace(entry) => {
+                                        let color = match entry.category {
+                                            PdTraceCategory::TypeCState => {
+                                                egui::Color32::from_rgb(100, 200, 255)
+                                            }
+                                            PdTraceCategory::ProtocolEvent => egui::Color32::LIGHT_GREEN,
+                                            PdTraceCategory::Unknown => egui::Color32::YELLOW,
+                                        };
+                                        ui.colored_label(
+                                            color,
+                                            egui::RichText::new(format!("[FW]   {}", entry.summary))
+                                                .monospace()
+                                                .size(row_height),
+                                        );
+                                    }
                                 }
                             }
                         });
@@ -775,7 +882,7 @@ async fn usb_streaming_task(tx: mpsc::UnboundedSender<UsbMessage>, mut cmd_rx: m
                 info!("Connect command received, rate={:?}, reset={}", initial_rate, usb_reset);
                 run_streaming_session(&tx, &mut cmd_rx, initial_rate, usb_reset).await;
             }
-            UsbCommand::SetSampleRate(_) | UsbCommand::Disconnect => {
+            UsbCommand::SetSampleRate(_) | UsbCommand::SetPdTraceEnabled(_) | UsbCommand::Disconnect => {
                 // Ignore these when not connected
                 debug!("Ignoring command while disconnected: {:?}", cmd);
             }
@@ -831,6 +938,7 @@ async fn run_streaming_session(
 
     // Streaming loop - poll for data and handle commands
     let mut error_count = 0;
+    let mut pd_trace_enabled = false;
     const MAX_ERRORS: u32 = 10;
 
     loop {
@@ -853,6 +961,13 @@ async fn run_streaming_session(
                     current_rate = new_rate;
                 }
             }
+            Ok(UsbCommand::SetPdTraceEnabled(enabled)) => {
+                pd_trace_enabled = enabled;
+                info!(
+                    "Firmware PD trace collection {}",
+                    if enabled { "enabled" } else { "disabled" }
+                );
+            }
             Ok(UsbCommand::Disconnect) => {
                 info!("Disconnect command received");
                 break;
@@ -870,8 +985,8 @@ async fn run_streaming_session(
             }
         }
 
-        // Request AdcQueue + PD data using library API
-        let mask = AttributeSet::single(Attribute::AdcQueue).with(Attribute::PdPacket);
+        // Request the regular streams and the opt-in firmware trace.
+        let mask = streaming_attribute_mask(pd_trace_enabled);
         match device.request_data(mask).await {
             Ok(packet) => {
                 error_count = 0;
@@ -892,6 +1007,11 @@ async fn run_streaming_session(
                 }
                 if let Some(status) = packet.get_pd_status() {
                     let _ = tx.send(UsbMessage::PdStatusUpdate(*status));
+                }
+                if let Some(trace) = packet.get_pd_trace()
+                    && (!trace.state_events.is_empty() || !trace.protocol_events.is_empty())
+                {
+                    let _ = tx.send(UsbMessage::PdTrace(trace.clone()));
                 }
             }
             Err(e) => {
@@ -918,6 +1038,15 @@ async fn run_streaming_session(
     info!("Stopping streaming");
     let _ = device.stop_graph_mode().await;
     let _ = tx.send(UsbMessage::Disconnected);
+}
+
+fn streaming_attribute_mask(pd_trace_enabled: bool) -> AttributeSet {
+    let mask = AttributeSet::single(Attribute::AdcQueue).with(Attribute::PdPacket);
+    if pd_trace_enabled {
+        mask.with(Attribute::PdTrace)
+    } else {
+        mask
+    }
 }
 
 async fn start_streaming(
@@ -958,4 +1087,45 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     eframe::run_native("POWER-Z KM003C Monitor", options, Box::new(|_cc| Ok(Box::new(app))))
         .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn firmware_trace_is_only_requested_when_enabled() {
+        let disabled = streaming_attribute_mask(false);
+        assert!(disabled.contains(Attribute::AdcQueue));
+        assert!(disabled.contains(Attribute::PdPacket));
+        assert!(!disabled.contains(Attribute::PdTrace));
+
+        let enabled = streaming_attribute_mask(true);
+        assert!(enabled.contains(Attribute::AdcQueue));
+        assert!(enabled.contains(Attribute::PdPacket));
+        assert!(enabled.contains(Attribute::PdTrace));
+    }
+
+    #[test]
+    fn pd_timeline_filters_and_orders_both_sources() {
+        let protocol_log = VecDeque::from([DecodedPdEntry {
+            timestamp_seconds: 12.25,
+            category: PdCategory::Control,
+            summary: "wire".to_string(),
+            details: Vec::new(),
+        }]);
+        let trace_log = VecDeque::from([PdTraceEntry {
+            timestamp_seconds: 11.0,
+            category: PdTraceCategory::TypeCState,
+            summary: "trace".to_string(),
+        }]);
+
+        let combined = pd_timeline_entries(&protocol_log, &trace_log, true, true);
+        assert!(matches!(combined[0], PdTimelineEntry::FirmwareTrace(_)));
+        assert!(matches!(combined[1], PdTimelineEntry::Protocol(_)));
+
+        let protocol_only = pd_timeline_entries(&protocol_log, &trace_log, true, false);
+        assert_eq!(protocol_only.len(), 1);
+        assert!(matches!(protocol_only[0], PdTimelineEntry::Protocol(_)));
+    }
 }

--- a/km003c-egui/src/main.rs
+++ b/km003c-egui/src/main.rs
@@ -1,22 +1,22 @@
+mod measurement;
 mod pd_connection;
 mod pd_decoder;
 mod pd_trace_view;
+mod recording;
 
 use eframe::egui;
 use egui_plot::{Line, Plot, PlotPoints};
-use km003c_lib::uom::si::electric_current::ampere;
 use km003c_lib::uom::si::electric_potential::volt;
-use km003c_lib::uom::si::power::watt;
-use km003c_lib::uom::si::time::second;
 use km003c_lib::{
     AdcQueueSample, DeviceConfig, DeviceState, GraphSampleRate, KM003C, PdTrace,
     packet::{Attribute, AttributeSet},
     pd::{PdEvent, PdEventData, PdStatus},
-    sequence_elapsed,
 };
+use measurement::{MeasurementAccumulator, MeasurementSample, PlotMetric};
 use pd_connection::PdConnectionTracker;
 use pd_decoder::{DecodedPdEntry, PdCategory, PdDecoder};
 use pd_trace_view::{PdTraceCategory, PdTraceEntry, decode_trace};
+use recording::{Recorder, RecordingEvent, RecordingFormat, RecordingMetadata, RecordingSummary};
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
@@ -174,8 +174,10 @@ impl TimeWindow {
 }
 
 struct PowerMonitorApp {
-    /// Data points for plotting (timestamp, voltage, current, power)
-    data_points: VecDeque<(f64, f64, f64, f64)>,
+    /// Complete live samples retained for plotting
+    data_points: VecDeque<MeasurementSample>,
+    /// Unwraps device time and integrates charge and energy
+    measurement_accumulator: MeasurementAccumulator,
     /// Receiver for USB messages
     usb_receiver: mpsc::UnboundedReceiver<UsbMessage>,
     /// Sender for commands to USB task
@@ -196,18 +198,22 @@ struct PowerMonitorApp {
     max_points: usize,
     /// Total samples received
     total_samples: u64,
-    /// Last sequence number (for gap detection)
-    last_sequence: Option<u16>,
-    /// Plot timestamp assigned to the last received sample
-    last_sample_timestamp: Option<f64>,
     /// Dropped sample count
     dropped_samples: u64,
     /// Current readings for display
     current_voltage: f64,
     current_current: f64,
     current_power: f64,
-    /// Time offset for plotting (first sample time)
-    time_base: Option<std::time::Instant>,
+    /// Metric selected independently for each plot
+    plot_metrics: [PlotMetric; 3],
+    /// Preferred output format for live capture
+    recording_format: RecordingFormat,
+    /// Active or finalizing background recorder
+    recorder: Option<Recorder>,
+    /// Last recorder status shown to the user
+    recording_status: String,
+    /// Summary of the last completed recording
+    last_recording: Option<RecordingSummary>,
     /// PD protocol decoder
     pd_decoder: PdDecoder,
     /// Decoded PD log entries
@@ -238,6 +244,7 @@ impl PowerMonitorApp {
     fn new(usb_receiver: mpsc::UnboundedReceiver<UsbMessage>, cmd_sender: mpsc::UnboundedSender<UsbCommand>) -> Self {
         Self {
             data_points: VecDeque::new(),
+            measurement_accumulator: MeasurementAccumulator::default(),
             usb_receiver,
             cmd_sender,
             device_state: None,
@@ -248,13 +255,15 @@ impl PowerMonitorApp {
             time_window: TimeWindow::Sec30,
             max_points: 100000, // Safety cap for memory
             total_samples: 0,
-            last_sequence: None,
-            last_sample_timestamp: None,
             dropped_samples: 0,
             current_voltage: 0.0,
             current_current: 0.0,
             current_power: 0.0,
-            time_base: None,
+            plot_metrics: [PlotMetric::Voltage, PlotMetric::Current, PlotMetric::Power],
+            recording_format: RecordingFormat::Parquet,
+            recorder: None,
+            recording_status: "Not recording".to_string(),
+            last_recording: None,
             pd_decoder: PdDecoder::new(),
             pd_log: VecDeque::new(),
             max_pd_entries: 1000,
@@ -285,45 +294,20 @@ impl PowerMonitorApp {
                     self.status = format!("Connection failed: {}", err);
                 }
                 UsbMessage::Samples(samples) => {
-                    let Some((first_sample, last_sample)) = samples.first().zip(samples.last()) else {
-                        continue;
-                    };
-                    let batch_duration = sequence_elapsed(first_sample.sequence, last_sample.sequence);
-                    let now = std::time::Instant::now();
-                    if self.time_base.is_none() {
-                        let batch_duration_std = Duration::from_secs_f64(batch_duration.get::<second>());
-                        self.time_base = Some(now.checked_sub(batch_duration_std).unwrap_or(now));
-                    }
-                    let time_base = self.time_base.unwrap();
-                    let arrival_timestamp = time_base.elapsed().as_secs_f64();
-                    let first_timestamp = arrival_timestamp - batch_duration.get::<second>();
-
                     let rate = self.current_rate.to_graph_rate();
-                    for sample in &samples {
-                        let timestamp = match (self.last_sequence, self.last_sample_timestamp) {
-                            (Some(last_sequence), Some(last_timestamp)) => {
-                                last_timestamp + sequence_elapsed(last_sequence, sample.sequence).get::<second>()
-                            }
-                            _ => first_timestamp,
-                        };
+                    let measurements = samples
+                        .into_iter()
+                        .map(|sample| self.measurement_accumulator.push(sample, rate))
+                        .collect::<Vec<_>>();
 
-                        if let Some(last_seq) = self.last_sequence {
-                            self.dropped_samples += rate.missing_samples(last_seq, sample.sequence) as u64;
-                        }
-                        self.last_sequence = Some(sample.sequence);
-                        self.last_sample_timestamp = Some(timestamp);
-
-                        self.data_points.push_back((
-                            timestamp,
-                            sample.vbus.get::<volt>(),
-                            sample.ibus.abs().get::<ampere>(),
-                            sample.power.abs().get::<watt>(),
-                        ));
+                    for measurement in &measurements {
+                        self.data_points.push_back(*measurement);
+                        self.dropped_samples = measurement.cumulative_missing_samples;
 
                         // Update current readings
-                        self.current_voltage = sample.vbus.get::<volt>();
-                        self.current_current = sample.ibus.get::<ampere>();
-                        self.current_power = sample.power.get::<watt>();
+                        self.current_voltage = measurement.vbus_uv as f64 / 1_000_000.0;
+                        self.current_current = measurement.ibus_ua as f64 / 1_000_000.0;
+                        self.current_power = measurement.power_uw as f64 / 1_000_000.0;
 
                         self.total_samples += 1;
 
@@ -332,14 +316,22 @@ impl PowerMonitorApp {
                             self.data_points.pop_front();
                         }
                     }
+
+                    if let Some(recorder) = &mut self.recorder
+                        && let Err(error) = recorder.push(&measurements)
+                    {
+                        self.recording_status = error;
+                        let _ = recorder.request_finish();
+                    }
                 }
                 UsbMessage::StreamingStarted(rate) => {
                     self.streaming = true;
                     self.current_rate = SampleRateOption::from_graph_rate(rate);
                     self.selected_rate = self.current_rate;
                     self.status = format!("Streaming at {}", self.current_rate.label());
-                    // Reset sequence tracking because the expected step changed.
-                    self.last_sequence = None;
+                    // A rate change starts a new continuity segment without
+                    // inventing an interval across StopGraph/StartGraph.
+                    self.measurement_accumulator.reset_continuity();
                 }
                 UsbMessage::PdEvents(events) => {
                     for event in &events {
@@ -387,20 +379,20 @@ impl PowerMonitorApp {
                     self.device_state = None;
                     self.pd_status = None;
                     self.pd_connection = PdConnectionTracker::default();
+                    self.stop_recording();
                 }
             }
         }
 
         self.pd_connection.update(std::time::Instant::now());
+        self.poll_recording();
     }
 
     fn clear_data(&mut self) {
         self.data_points.clear();
         self.total_samples = 0;
         self.dropped_samples = 0;
-        self.last_sequence = None;
-        self.last_sample_timestamp = None;
-        self.time_base = None;
+        self.measurement_accumulator.reset();
         info!("Data cleared");
     }
 
@@ -408,6 +400,124 @@ impl PowerMonitorApp {
         self.pd_log.clear();
         self.pd_trace_log.clear();
         info!("PD timeline cleared");
+    }
+
+    fn start_recording(&mut self) {
+        let Some(state) = &self.device_state else {
+            self.recording_status = "Connect the KM003C before starting a recording".to_string();
+            return;
+        };
+        if self.recorder.is_some() {
+            return;
+        }
+
+        let metadata = RecordingMetadata {
+            model: state.info.model.clone(),
+            firmware: state.info.fw_version.clone(),
+            serial: state.info.serial_id.clone(),
+        };
+        let Some(path) = self.select_recording_path("km003c-live", "Save KM003C live recording") else {
+            return;
+        };
+        match Recorder::start(
+            path.clone(),
+            self.recording_format,
+            metadata,
+            self.data_points.back().copied(),
+        ) {
+            Ok(recorder) => {
+                self.recording_status = format!("Recording to {}", path.display());
+                self.last_recording = None;
+                self.recorder = Some(recorder);
+            }
+            Err(error) => self.recording_status = error,
+        }
+    }
+
+    fn export_buffer(&mut self) {
+        let Some(state) = &self.device_state else {
+            self.recording_status = "Connect the KM003C before exporting data".to_string();
+            return;
+        };
+        let Some(first) = self.data_points.front().copied() else {
+            self.recording_status = "The plot buffer is empty".to_string();
+            return;
+        };
+        let metadata = RecordingMetadata {
+            model: state.info.model.clone(),
+            firmware: state.info.fw_version.clone(),
+            serial: state.info.serial_id.clone(),
+        };
+        let Some(path) = self.select_recording_path("km003c-buffer", "Export KM003C plot buffer") else {
+            return;
+        };
+
+        match Recorder::start(path.clone(), self.recording_format, metadata, Some(first)) {
+            Ok(mut recorder) => {
+                let samples = self.data_points.iter().copied().collect::<Vec<_>>();
+                match recorder.push(&samples).and_then(|()| recorder.request_finish()) {
+                    Ok(()) => {
+                        self.recording_status = format!("Exporting {}", path.display());
+                        self.last_recording = None;
+                        self.recorder = Some(recorder);
+                    }
+                    Err(error) => self.recording_status = error,
+                }
+            }
+            Err(error) => self.recording_status = error,
+        }
+    }
+
+    fn select_recording_path(&self, prefix: &str, title: &str) -> Option<std::path::PathBuf> {
+        let unix_seconds = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_secs());
+        let filename = format!("{prefix}-{unix_seconds}.{}", self.recording_format.extension());
+        let mut path = rfd::FileDialog::new()
+            .set_title(title)
+            .add_filter(self.recording_format.label(), &[self.recording_format.extension()])
+            .set_file_name(filename)
+            .save_file()?;
+        path.set_extension(self.recording_format.extension());
+        Some(path)
+    }
+
+    fn stop_recording(&mut self) {
+        let Some(recorder) = &mut self.recorder else {
+            return;
+        };
+        if let Err(error) = recorder.request_finish() {
+            self.recording_status = error;
+        } else {
+            self.recording_status = format!("Finalizing {}", recorder.path.display());
+        }
+    }
+
+    fn poll_recording(&mut self) {
+        let event = self.recorder.as_mut().and_then(Recorder::poll_event);
+        match event {
+            Some(RecordingEvent::Finished(summary)) => {
+                self.recording_status = format!(
+                    "Saved {} samples to {} ({:.6}% complete)",
+                    summary.rows,
+                    summary.path.display(),
+                    summary.completeness_percent()
+                );
+                self.last_recording = Some(summary);
+                self.recorder = None;
+            }
+            Some(RecordingEvent::Interrupted(summary, reason)) => {
+                self.recording_status =
+                    format!("{reason}; saved {} samples to {}", summary.rows, summary.path.display());
+                self.last_recording = Some(summary);
+                self.recorder = None;
+            }
+            Some(RecordingEvent::Failed(error)) => {
+                self.recording_status = error;
+                self.recorder = None;
+            }
+            None => {}
+        }
     }
 }
 
@@ -630,24 +740,25 @@ impl eframe::App for PowerMonitorApp {
             ui.separator();
 
             // Sample rate selector
-            ui.horizontal(|ui| {
-                ui.label("Sample Rate:");
-                let prev_rate = self.selected_rate;
-                egui::ComboBox::from_id_salt("sample_rate")
-                    .selected_text(self.selected_rate.label())
-                    .show_ui(ui, |ui| {
-                        for rate in SampleRateOption::all() {
-                            ui.selectable_value(&mut self.selected_rate, *rate, rate.label());
-                        }
-                    });
+            ui.add_enabled_ui(self.recorder.is_none(), |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("Sample Rate:");
+                    let prev_rate = self.selected_rate;
+                    egui::ComboBox::from_id_salt("sample_rate")
+                        .selected_text(self.selected_rate.label())
+                        .show_ui(ui, |ui| {
+                            for rate in SampleRateOption::all() {
+                                ui.selectable_value(&mut self.selected_rate, *rate, rate.label());
+                            }
+                        });
 
-                // If rate changed, send command to USB task
-                if self.selected_rate != prev_rate && self.device_state.is_some() {
-                    info!("Sample rate changed to {}", self.selected_rate.label());
-                    let _ = self
-                        .cmd_sender
-                        .send(UsbCommand::SetSampleRate(self.selected_rate.to_graph_rate()));
-                }
+                    if self.selected_rate != prev_rate && self.device_state.is_some() {
+                        info!("Sample rate changed to {}", self.selected_rate.label());
+                        let _ = self
+                            .cmd_sender
+                            .send(UsbCommand::SetSampleRate(self.selected_rate.to_graph_rate()));
+                    }
+                });
             });
 
             ui.add_space(5.0);
@@ -665,12 +776,91 @@ impl eframe::App for PowerMonitorApp {
             });
 
             ui.add_space(10.0);
+            ui.label("Plot metrics:");
+            for (index, metric) in self.plot_metrics.iter_mut().enumerate() {
+                ui.horizontal(|ui| {
+                    ui.label(format!("{}:", index + 1));
+                    egui::ComboBox::from_id_salt(("plot_metric", index))
+                        .selected_text(metric.label())
+                        .show_ui(ui, |ui| {
+                            for option in PlotMetric::ALL {
+                                ui.selectable_value(metric, option, option.label());
+                            }
+                        });
+                });
+            }
+
+            ui.add_space(10.0);
 
             ui.horizontal(|ui| {
-                if ui.button("Clear Data").clicked() {
+                if ui
+                    .add_enabled(self.recorder.is_none(), egui::Button::new("Clear Data"))
+                    .clicked()
+                {
                     self.clear_data();
                 }
             });
+
+            ui.add_space(20.0);
+            ui.separator();
+            ui.heading("Live Capture");
+            ui.separator();
+
+            ui.add_enabled_ui(self.recorder.is_none(), |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("Format:");
+                    egui::ComboBox::from_id_salt("recording_format")
+                        .selected_text(self.recording_format.label())
+                        .show_ui(ui, |ui| {
+                            for format in RecordingFormat::ALL {
+                                ui.selectable_value(&mut self.recording_format, format, format.label());
+                            }
+                        });
+                });
+            });
+
+            match &self.recorder {
+                Some(recorder) if recorder.is_finishing() => {
+                    ui.add_enabled(false, egui::Button::new("Finalizing..."));
+                }
+                Some(_) => {
+                    if ui.button("Stop Recording").clicked() {
+                        self.stop_recording();
+                    }
+                }
+                None => {
+                    ui.horizontal(|ui| {
+                        if ui
+                            .add_enabled(self.streaming, egui::Button::new("Start Recording"))
+                            .clicked()
+                        {
+                            self.start_recording();
+                        }
+                        if ui
+                            .add_enabled(!self.data_points.is_empty(), egui::Button::new("Export Buffer"))
+                            .clicked()
+                        {
+                            self.export_buffer();
+                        }
+                    });
+                }
+            }
+
+            if let Some(recorder) = &self.recorder {
+                ui.label(format!("Samples: {}", recorder.rows));
+                ui.label(format!("Missing: {}", recorder.missing_samples));
+                let completeness = if recorder.elapsed_us == 0 {
+                    100.0
+                } else {
+                    (1.0 - recorder.interpolated_duration_us as f64 / recorder.elapsed_us as f64).max(0.0)
+                        * 100.0
+                };
+                ui.label(format!("Completeness: {completeness:.6}%"));
+            } else if let Some(summary) = &self.last_recording {
+                ui.label(format!("Last capture: {} samples", summary.rows));
+                ui.label(format!("Completeness: {:.6}%", summary.completeness_percent()));
+            }
+            ui.small(&self.recording_status);
 
             ui.add_space(5.0);
 
@@ -774,93 +964,31 @@ impl eframe::App for PowerMonitorApp {
             let available_height = ui.available_height();
             let plot_height = (available_height - 30.0) / 3.0;
 
-            // Calculate time cutoff for filtering
-            // When streaming, use real elapsed time; when stopped, use last data point time
-            let current_time = if self.streaming {
-                self.time_base.map(|tb| tb.elapsed().as_secs_f64()).unwrap_or(0.0)
-            } else {
-                // Use the last data point's timestamp when not streaming
-                self.data_points.back().map(|(t, _, _, _)| *t).unwrap_or(0.0)
-            };
+            let current_time = self.data_points.back().map_or(0.0, |sample| sample.elapsed_seconds());
             let min_time = self
                 .time_window
                 .seconds()
                 .map(|window| (current_time - window).max(0.0));
 
-            // Filter function for time window
-            let in_window = |t: &f64| -> bool {
-                match min_time {
-                    Some(min) => *t >= min,
-                    None => true, // "All" - show everything
-                }
-            };
-
-            // Voltage plot
-            ui.label("Voltage (V)");
-            Plot::new("voltage_plot")
-                .height(plot_height)
-                .show_axes([true, true])
-                .show_grid(true)
-                .allow_boxed_zoom(true)
-                .allow_drag(true)
-                .allow_scroll(true)
-                .show(ui, |plot_ui| {
-                    if !self.data_points.is_empty() {
+            for (index, metric) in self.plot_metrics.into_iter().enumerate() {
+                ui.label(format!("{} ({})", metric.label(), metric.unit()));
+                Plot::new(("measurement_plot", index))
+                    .height(plot_height)
+                    .show_axes([true, true])
+                    .show_grid(true)
+                    .allow_boxed_zoom(true)
+                    .allow_drag(true)
+                    .allow_scroll(true)
+                    .show(ui, |plot_ui| {
                         let points: PlotPoints = self
                             .data_points
                             .iter()
-                            .filter(|(t, _, _, _)| in_window(t))
-                            .map(|(t, v, _, _)| [*t, *v])
+                            .filter(|sample| min_time.is_none_or(|min| sample.elapsed_seconds() >= min))
+                            .map(|sample| [sample.elapsed_seconds(), metric.value(sample)])
                             .collect();
-                        plot_ui.line(Line::new("Voltage", points).color(egui::Color32::GREEN).width(1.5_f32));
-                    }
-                });
-
-            // Current plot
-            ui.label("Current (A)");
-            Plot::new("current_plot")
-                .height(plot_height)
-                .show_axes([true, true])
-                .show_grid(true)
-                .allow_boxed_zoom(true)
-                .allow_drag(true)
-                .allow_scroll(true)
-                .show(ui, |plot_ui| {
-                    if !self.data_points.is_empty() {
-                        let points: PlotPoints = self
-                            .data_points
-                            .iter()
-                            .filter(|(t, _, _, _)| in_window(t))
-                            .map(|(t, _, i, _)| [*t, *i])
-                            .collect();
-                        plot_ui.line(Line::new("Current", points).color(egui::Color32::BLUE).width(1.5_f32));
-                    }
-                });
-
-            // Power plot
-            ui.label("Power (W)");
-            Plot::new("power_plot")
-                .height(plot_height)
-                .show_axes([true, true])
-                .show_grid(true)
-                .allow_boxed_zoom(true)
-                .allow_drag(true)
-                .allow_scroll(true)
-                .show(ui, |plot_ui| {
-                    if !self.data_points.is_empty() {
-                        let points: PlotPoints = self
-                            .data_points
-                            .iter()
-                            .filter(|(t, _, _, _)| in_window(t))
-                            .map(|(t, _, _, p)| [*t, *p])
-                            .collect();
-                        plot_ui.line(
-                            Line::new("Power", points)
-                                .color(egui::Color32::from_rgb(255, 165, 0)) // Orange
-                                .width(1.5_f32),
-                        );
-                    }
-                });
+                        plot_ui.line(Line::new(metric.label(), points).color(metric.color()).width(1.5_f32));
+                    });
+            }
         });
     }
 }

--- a/km003c-egui/src/main.rs
+++ b/km003c-egui/src/main.rs
@@ -200,6 +200,8 @@ struct PowerMonitorApp {
     total_samples: u64,
     /// Dropped sample count
     dropped_samples: u64,
+    /// Duplicate, stale, or invalid-sequence samples excluded from measurements
+    discarded_sequence_samples: u64,
     /// Current readings for display
     current_voltage: f64,
     current_current: f64,
@@ -256,6 +258,7 @@ impl PowerMonitorApp {
             max_points: 100000, // Safety cap for memory
             total_samples: 0,
             dropped_samples: 0,
+            discarded_sequence_samples: 0,
             current_voltage: 0.0,
             current_current: 0.0,
             current_power: 0.0,
@@ -297,8 +300,10 @@ impl PowerMonitorApp {
                     let rate = self.current_rate.to_graph_rate();
                     let measurements = samples
                         .into_iter()
-                        .map(|sample| self.measurement_accumulator.push(sample, rate))
+                        .filter_map(|sample| self.measurement_accumulator.push(sample, rate))
                         .collect::<Vec<_>>();
+                    self.discarded_sequence_samples =
+                        self.measurement_accumulator.cumulative_discarded_sequence_samples();
 
                     for measurement in &measurements {
                         self.data_points.push_back(*measurement);
@@ -392,6 +397,7 @@ impl PowerMonitorApp {
         self.data_points.clear();
         self.total_samples = 0;
         self.dropped_samples = 0;
+        self.discarded_sequence_samples = 0;
         self.measurement_accumulator.reset();
         info!("Data cleared");
     }
@@ -729,6 +735,17 @@ impl eframe::App for PowerMonitorApp {
                     );
                     ui.end_row();
 
+                    ui.label("Discarded:");
+                    ui.colored_label(
+                        if self.discarded_sequence_samples > 0 {
+                            egui::Color32::YELLOW
+                        } else {
+                            egui::Color32::GREEN
+                        },
+                        format!("{}", self.discarded_sequence_samples),
+                    );
+                    ui.end_row();
+
                     ui.label("Buffer:");
                     ui.label(format!("{} pts", self.data_points.len()));
                     ui.end_row();
@@ -849,6 +866,7 @@ impl eframe::App for PowerMonitorApp {
             if let Some(recorder) = &self.recorder {
                 ui.label(format!("Samples: {}", recorder.rows));
                 ui.label(format!("Missing: {}", recorder.missing_samples));
+                ui.label(format!("Discarded: {}", recorder.discarded_sequence_samples));
                 let completeness = if recorder.elapsed_us == 0 {
                     100.0
                 } else {
@@ -858,6 +876,7 @@ impl eframe::App for PowerMonitorApp {
                 ui.label(format!("Completeness: {completeness:.6}%"));
             } else if let Some(summary) = &self.last_recording {
                 ui.label(format!("Last capture: {} samples", summary.rows));
+                ui.label(format!("Discarded: {}", summary.discarded_sequence_samples));
                 ui.label(format!("Completeness: {:.6}%", summary.completeness_percent()));
             }
             ui.small(&self.recording_status);

--- a/km003c-egui/src/measurement.rs
+++ b/km003c-egui/src/measurement.rs
@@ -27,6 +27,8 @@ pub(crate) struct MeasurementSample {
     pub(crate) power_uw: i64,
     pub(crate) charge_uah: f64,
     pub(crate) energy_uwh: f64,
+    pub(crate) charge_throughput_uah: f64,
+    pub(crate) energy_throughput_uwh: f64,
     pub(crate) cc1_uv: i64,
     pub(crate) cc2_uv: i64,
     pub(crate) dp_uv: i64,
@@ -49,6 +51,8 @@ pub(crate) struct MeasurementAccumulator {
     pending_discarded_sequence_samples: u32,
     charge_twice_ua_us: i128,
     energy_twice_uw_us: i128,
+    charge_throughput_twice_ua_us: i128,
+    energy_throughput_twice_uw_us: i128,
     previous: Option<PreviousSample>,
 }
 
@@ -86,6 +90,10 @@ impl MeasurementAccumulator {
         if let Some(previous) = self.previous {
             self.charge_twice_ua_us += (i128::from(previous.current_ua) + i128::from(ibus_ua)) * i128::from(delta_us);
             self.energy_twice_uw_us += (i128::from(previous.power_uw) + i128::from(power_uw)) * i128::from(delta_us);
+            self.charge_throughput_twice_ua_us +=
+                (i128::from(previous.current_ua).abs() + i128::from(ibus_ua).abs()) * i128::from(delta_us);
+            self.energy_throughput_twice_uw_us +=
+                (i128::from(previous.power_uw).abs() + i128::from(power_uw).abs()) * i128::from(delta_us);
         }
 
         self.elapsed_us += delta_us;
@@ -110,6 +118,8 @@ impl MeasurementAccumulator {
             power_uw,
             charge_uah: self.charge_twice_ua_us as f64 / (2.0 * MICROSECONDS_PER_HOUR),
             energy_uwh: self.energy_twice_uw_us as f64 / (2.0 * MICROSECONDS_PER_HOUR),
+            charge_throughput_uah: self.charge_throughput_twice_ua_us as f64 / (2.0 * MICROSECONDS_PER_HOUR),
+            energy_throughput_uwh: self.energy_throughput_twice_uw_us as f64 / (2.0 * MICROSECONDS_PER_HOUR),
             cc1_uv: sample.cc1.get::<microvolt>().round() as i64,
             cc2_uv: sample.cc2.get::<microvolt>().round() as i64,
             dp_uv: sample.vdp.get::<microvolt>().round() as i64,
@@ -147,7 +157,9 @@ pub(crate) enum PlotMetric {
     Power,
     SignedPower,
     Charge,
+    SignedCharge,
     Energy,
+    SignedEnergy,
     Cc1,
     Cc2,
     DPlus,
@@ -155,14 +167,16 @@ pub(crate) enum PlotMetric {
 }
 
 impl PlotMetric {
-    pub(crate) const ALL: [Self; 11] = [
+    pub(crate) const ALL: [Self; 13] = [
         Self::Voltage,
         Self::Current,
         Self::SignedCurrent,
         Self::Power,
         Self::SignedPower,
         Self::Charge,
+        Self::SignedCharge,
         Self::Energy,
+        Self::SignedEnergy,
         Self::Cc1,
         Self::Cc2,
         Self::DPlus,
@@ -176,8 +190,10 @@ impl PlotMetric {
             Self::SignedCurrent => "Current (signed)",
             Self::Power => "Power (absolute)",
             Self::SignedPower => "Power (signed)",
-            Self::Charge => "Charge",
-            Self::Energy => "Energy",
+            Self::Charge => "Charge transferred",
+            Self::SignedCharge => "Net charge (signed)",
+            Self::Energy => "Energy transferred",
+            Self::SignedEnergy => "Net energy (signed)",
             Self::Cc1 => "CC1 voltage",
             Self::Cc2 => "CC2 voltage",
             Self::DPlus => "D+ voltage",
@@ -190,8 +206,8 @@ impl PlotMetric {
             Self::Voltage | Self::Cc1 | Self::Cc2 | Self::DPlus | Self::DMinus => "V",
             Self::Current | Self::SignedCurrent => "A",
             Self::Power | Self::SignedPower => "W",
-            Self::Charge => "mAh",
-            Self::Energy => "mWh",
+            Self::Charge | Self::SignedCharge => "mAh",
+            Self::Energy | Self::SignedEnergy => "mWh",
         }
     }
 
@@ -202,8 +218,10 @@ impl PlotMetric {
             Self::SignedCurrent => sample.ibus_ua as f64 / 1_000_000.0,
             Self::Power => (sample.power_uw as f64 / 1_000_000.0).abs(),
             Self::SignedPower => sample.power_uw as f64 / 1_000_000.0,
-            Self::Charge => sample.charge_uah / 1_000.0,
-            Self::Energy => sample.energy_uwh / 1_000.0,
+            Self::Charge => sample.charge_throughput_uah / 1_000.0,
+            Self::SignedCharge => sample.charge_uah / 1_000.0,
+            Self::Energy => sample.energy_throughput_uwh / 1_000.0,
+            Self::SignedEnergy => sample.energy_uwh / 1_000.0,
             Self::Cc1 => sample.cc1_uv as f64 / 1_000_000.0,
             Self::Cc2 => sample.cc2_uv as f64 / 1_000_000.0,
             Self::DPlus => sample.dp_uv as f64 / 1_000_000.0,
@@ -216,8 +234,8 @@ impl PlotMetric {
             Self::Voltage => egui::Color32::GREEN,
             Self::Current | Self::SignedCurrent => egui::Color32::BLUE,
             Self::Power | Self::SignedPower => egui::Color32::from_rgb(255, 165, 0),
-            Self::Charge => egui::Color32::from_rgb(180, 120, 255),
-            Self::Energy => egui::Color32::from_rgb(255, 100, 180),
+            Self::Charge | Self::SignedCharge => egui::Color32::from_rgb(180, 120, 255),
+            Self::Energy | Self::SignedEnergy => egui::Color32::from_rgb(255, 100, 180),
             Self::Cc1 => egui::Color32::from_rgb(100, 200, 255),
             Self::Cc2 => egui::Color32::from_rgb(80, 220, 180),
             Self::DPlus => egui::Color32::from_rgb(255, 120, 120),
@@ -258,6 +276,8 @@ mod tests {
         assert_eq!(second.elapsed_us, 500_000);
         assert!((second.charge_uah - 277.777_777).abs() < 0.000_001);
         assert!((second.energy_uwh - 2_777.777_777).abs() < 0.000_001);
+        assert!((second.charge_throughput_uah - 277.777_777).abs() < 0.000_001);
+        assert!((second.energy_throughput_uwh - 2_777.777_777).abs() < 0.000_001);
         assert_eq!(second.missing_samples, 0);
     }
 
@@ -323,5 +343,19 @@ mod tests {
 
         assert_eq!(after_rollover.elapsed_us, 1_000);
         assert_eq!(after_rollover.cumulative_discarded_sequence_samples, 0);
+    }
+
+    #[test]
+    fn throughput_stays_positive_when_direction_changes() {
+        let mut accumulator = MeasurementAccumulator::default();
+        accumulator
+            .push(sample(0, 5.0, -1.0), GraphSampleRate::Sps1000)
+            .unwrap();
+        let zero_crossing = accumulator.push(sample(1, 5.0, 1.0), GraphSampleRate::Sps1000).unwrap();
+
+        assert_eq!(zero_crossing.charge_uah, 0.0);
+        assert_eq!(zero_crossing.energy_uwh, 0.0);
+        assert!((zero_crossing.charge_throughput_uah - 0.277_777).abs() < 0.000_001);
+        assert!((zero_crossing.energy_throughput_uwh - 1.388_888).abs() < 0.000_001);
     }
 }

--- a/km003c-egui/src/measurement.rs
+++ b/km003c-egui/src/measurement.rs
@@ -1,0 +1,266 @@
+use eframe::egui;
+use km003c_lib::uom::si::electric_current::microampere;
+use km003c_lib::uom::si::electric_potential::microvolt;
+use km003c_lib::uom::si::power::microwatt;
+use km003c_lib::{AdcQueueSample, GraphSampleRate};
+
+const MICROSECONDS_PER_MILLISECOND: u64 = 1_000;
+const MICROSECONDS_PER_HOUR: f64 = 3_600_000_000.0;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct MeasurementSample {
+    pub(crate) elapsed_us: u64,
+    pub(crate) sample_index: u64,
+    pub(crate) sequence: u16,
+    pub(crate) marker: u16,
+    pub(crate) sample_rate_hz: u16,
+    pub(crate) missing_samples: u16,
+    pub(crate) gap_duration_us: u64,
+    pub(crate) interpolated: bool,
+    pub(crate) cumulative_missing_samples: u64,
+    pub(crate) cumulative_interpolated_duration_us: u64,
+    pub(crate) vbus_uv: i64,
+    pub(crate) ibus_ua: i64,
+    pub(crate) power_uw: i64,
+    pub(crate) charge_uah: f64,
+    pub(crate) energy_uwh: f64,
+    pub(crate) cc1_uv: i64,
+    pub(crate) cc2_uv: i64,
+    pub(crate) dp_uv: i64,
+    pub(crate) dm_uv: i64,
+}
+
+impl MeasurementSample {
+    pub(crate) fn elapsed_seconds(self) -> f64 {
+        self.elapsed_us as f64 / 1_000_000.0
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct MeasurementAccumulator {
+    elapsed_us: u64,
+    sample_index: u64,
+    cumulative_missing_samples: u64,
+    cumulative_interpolated_duration_us: u64,
+    charge_twice_ua_us: i128,
+    energy_twice_uw_us: i128,
+    previous: Option<PreviousSample>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PreviousSample {
+    sequence: u16,
+    current_ua: i64,
+    power_uw: i64,
+}
+
+impl MeasurementAccumulator {
+    pub(crate) fn push(&mut self, sample: AdcQueueSample, rate: GraphSampleRate) -> MeasurementSample {
+        let vbus_uv = sample.vbus.get::<microvolt>().round() as i64;
+        let ibus_ua = sample.ibus.get::<microampere>().round() as i64;
+        let power_uw = sample.power.get::<microwatt>().round() as i64;
+        let expected_ticks = u64::from(rate.sequence_step());
+
+        let (missing_samples, delta_us) = self.previous.map_or((0, 0), |previous| {
+            let delta_ticks = u64::from(sample.sequence.wrapping_sub(previous.sequence));
+            let missing = rate.missing_samples(previous.sequence, sample.sequence);
+            (missing, delta_ticks * MICROSECONDS_PER_MILLISECOND)
+        });
+        let gap_duration_us = u64::from(missing_samples) * expected_ticks * MICROSECONDS_PER_MILLISECOND;
+
+        if let Some(previous) = self.previous {
+            self.charge_twice_ua_us += (i128::from(previous.current_ua) + i128::from(ibus_ua)) * i128::from(delta_us);
+            self.energy_twice_uw_us += (i128::from(previous.power_uw) + i128::from(power_uw)) * i128::from(delta_us);
+        }
+
+        self.elapsed_us += delta_us;
+        self.cumulative_missing_samples += u64::from(missing_samples);
+        self.cumulative_interpolated_duration_us += gap_duration_us;
+
+        let decoded = MeasurementSample {
+            elapsed_us: self.elapsed_us,
+            sample_index: self.sample_index,
+            sequence: sample.sequence,
+            marker: sample.marker,
+            sample_rate_hz: rate.frequency().get::<km003c_lib::uom::si::frequency::hertz>() as u16,
+            missing_samples,
+            gap_duration_us,
+            interpolated: missing_samples > 0,
+            cumulative_missing_samples: self.cumulative_missing_samples,
+            cumulative_interpolated_duration_us: self.cumulative_interpolated_duration_us,
+            vbus_uv,
+            ibus_ua,
+            power_uw,
+            charge_uah: self.charge_twice_ua_us as f64 / (2.0 * MICROSECONDS_PER_HOUR),
+            energy_uwh: self.energy_twice_uw_us as f64 / (2.0 * MICROSECONDS_PER_HOUR),
+            cc1_uv: sample.cc1.get::<microvolt>().round() as i64,
+            cc2_uv: sample.cc2.get::<microvolt>().round() as i64,
+            dp_uv: sample.vdp.get::<microvolt>().round() as i64,
+            dm_uv: sample.vdm.get::<microvolt>().round() as i64,
+        };
+
+        self.previous = Some(PreviousSample {
+            sequence: sample.sequence,
+            current_ua: ibus_ua,
+            power_uw,
+        });
+        self.sample_index += 1;
+        decoded
+    }
+
+    pub(crate) fn reset_continuity(&mut self) {
+        self.previous = None;
+    }
+
+    pub(crate) fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlotMetric {
+    Voltage,
+    Current,
+    SignedCurrent,
+    Power,
+    SignedPower,
+    Charge,
+    Energy,
+    Cc1,
+    Cc2,
+    DPlus,
+    DMinus,
+}
+
+impl PlotMetric {
+    pub(crate) const ALL: [Self; 11] = [
+        Self::Voltage,
+        Self::Current,
+        Self::SignedCurrent,
+        Self::Power,
+        Self::SignedPower,
+        Self::Charge,
+        Self::Energy,
+        Self::Cc1,
+        Self::Cc2,
+        Self::DPlus,
+        Self::DMinus,
+    ];
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Voltage => "Voltage",
+            Self::Current => "Current (absolute)",
+            Self::SignedCurrent => "Current (signed)",
+            Self::Power => "Power (absolute)",
+            Self::SignedPower => "Power (signed)",
+            Self::Charge => "Charge",
+            Self::Energy => "Energy",
+            Self::Cc1 => "CC1 voltage",
+            Self::Cc2 => "CC2 voltage",
+            Self::DPlus => "D+ voltage",
+            Self::DMinus => "D- voltage",
+        }
+    }
+
+    pub(crate) const fn unit(self) -> &'static str {
+        match self {
+            Self::Voltage | Self::Cc1 | Self::Cc2 | Self::DPlus | Self::DMinus => "V",
+            Self::Current | Self::SignedCurrent => "A",
+            Self::Power | Self::SignedPower => "W",
+            Self::Charge => "mAh",
+            Self::Energy => "mWh",
+        }
+    }
+
+    pub(crate) fn value(self, sample: &MeasurementSample) -> f64 {
+        match self {
+            Self::Voltage => sample.vbus_uv as f64 / 1_000_000.0,
+            Self::Current => (sample.ibus_ua as f64 / 1_000_000.0).abs(),
+            Self::SignedCurrent => sample.ibus_ua as f64 / 1_000_000.0,
+            Self::Power => (sample.power_uw as f64 / 1_000_000.0).abs(),
+            Self::SignedPower => sample.power_uw as f64 / 1_000_000.0,
+            Self::Charge => sample.charge_uah / 1_000.0,
+            Self::Energy => sample.energy_uwh / 1_000.0,
+            Self::Cc1 => sample.cc1_uv as f64 / 1_000_000.0,
+            Self::Cc2 => sample.cc2_uv as f64 / 1_000_000.0,
+            Self::DPlus => sample.dp_uv as f64 / 1_000_000.0,
+            Self::DMinus => sample.dm_uv as f64 / 1_000_000.0,
+        }
+    }
+
+    pub(crate) const fn color(self) -> egui::Color32 {
+        match self {
+            Self::Voltage => egui::Color32::GREEN,
+            Self::Current | Self::SignedCurrent => egui::Color32::BLUE,
+            Self::Power | Self::SignedPower => egui::Color32::from_rgb(255, 165, 0),
+            Self::Charge => egui::Color32::from_rgb(180, 120, 255),
+            Self::Energy => egui::Color32::from_rgb(255, 100, 180),
+            Self::Cc1 => egui::Color32::from_rgb(100, 200, 255),
+            Self::Cc2 => egui::Color32::from_rgb(80, 220, 180),
+            Self::DPlus => egui::Color32::from_rgb(255, 120, 120),
+            Self::DMinus => egui::Color32::from_rgb(120, 160, 255),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use km003c_lib::uom::si::electric_current::ampere;
+    use km003c_lib::uom::si::electric_potential::volt;
+    use km003c_lib::uom::si::f64::{ElectricCurrent, ElectricPotential};
+
+    fn sample(sequence: u16, voltage_v: f64, current_a: f64) -> AdcQueueSample {
+        let vbus = ElectricPotential::new::<volt>(voltage_v);
+        let ibus = ElectricCurrent::new::<ampere>(current_a);
+        AdcQueueSample {
+            sequence,
+            marker: 0x1234,
+            vbus,
+            ibus,
+            power: vbus * ibus,
+            cc1: ElectricPotential::new::<volt>(1.0),
+            cc2: ElectricPotential::new::<volt>(2.0),
+            vdp: ElectricPotential::new::<volt>(0.6),
+            vdm: ElectricPotential::new::<volt>(0.5),
+        }
+    }
+
+    #[test]
+    fn integrates_charge_and_energy_from_device_time() {
+        let mut accumulator = MeasurementAccumulator::default();
+        accumulator.push(sample(0, 10.0, 2.0), GraphSampleRate::Sps2);
+        let second = accumulator.push(sample(500, 10.0, 2.0), GraphSampleRate::Sps2);
+
+        assert_eq!(second.elapsed_us, 500_000);
+        assert!((second.charge_uah - 277.777_777).abs() < 0.000_001);
+        assert!((second.energy_uwh - 2_777.777_777).abs() < 0.000_001);
+        assert_eq!(second.missing_samples, 0);
+    }
+
+    #[test]
+    fn interpolates_across_gaps_and_records_their_quality() {
+        let mut accumulator = MeasurementAccumulator::default();
+        accumulator.push(sample(0, 10.0, 1.0), GraphSampleRate::Sps50);
+        let after_gap = accumulator.push(sample(60, 10.0, 3.0), GraphSampleRate::Sps50);
+
+        assert_eq!(after_gap.missing_samples, 2);
+        assert_eq!(after_gap.gap_duration_us, 40_000);
+        assert_eq!(after_gap.cumulative_missing_samples, 2);
+        assert_eq!(after_gap.cumulative_interpolated_duration_us, 40_000);
+        assert!(after_gap.interpolated);
+        assert!((after_gap.charge_uah - 33.333_333).abs() < 0.000_001);
+    }
+
+    #[test]
+    fn signed_and_absolute_metrics_are_distinct() {
+        let mut accumulator = MeasurementAccumulator::default();
+        let measurement = accumulator.push(sample(0, 5.0, -2.0), GraphSampleRate::Sps10);
+
+        assert_eq!(PlotMetric::Current.value(&measurement), 2.0);
+        assert_eq!(PlotMetric::SignedCurrent.value(&measurement), -2.0);
+        assert_eq!(PlotMetric::Power.value(&measurement), 10.0);
+        assert_eq!(PlotMetric::SignedPower.value(&measurement), -10.0);
+    }
+}

--- a/km003c-egui/src/measurement.rs
+++ b/km003c-egui/src/measurement.rs
@@ -6,6 +6,7 @@ use km003c_lib::{AdcQueueSample, GraphSampleRate};
 
 const MICROSECONDS_PER_MILLISECOND: u64 = 1_000;
 const MICROSECONDS_PER_HOUR: f64 = 3_600_000_000.0;
+const MAX_FORWARD_SEQUENCE_TICKS: u16 = i16::MAX as u16;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct MeasurementSample {
@@ -19,6 +20,8 @@ pub(crate) struct MeasurementSample {
     pub(crate) interpolated: bool,
     pub(crate) cumulative_missing_samples: u64,
     pub(crate) cumulative_interpolated_duration_us: u64,
+    pub(crate) discarded_sequence_samples: u32,
+    pub(crate) cumulative_discarded_sequence_samples: u64,
     pub(crate) vbus_uv: i64,
     pub(crate) ibus_ua: i64,
     pub(crate) power_uw: i64,
@@ -42,6 +45,8 @@ pub(crate) struct MeasurementAccumulator {
     sample_index: u64,
     cumulative_missing_samples: u64,
     cumulative_interpolated_duration_us: u64,
+    cumulative_discarded_sequence_samples: u64,
+    pending_discarded_sequence_samples: u32,
     charge_twice_ua_us: i128,
     energy_twice_uw_us: i128,
     previous: Option<PreviousSample>,
@@ -55,7 +60,7 @@ struct PreviousSample {
 }
 
 impl MeasurementAccumulator {
-    pub(crate) fn push(&mut self, sample: AdcQueueSample, rate: GraphSampleRate) -> MeasurementSample {
+    pub(crate) fn push(&mut self, sample: AdcQueueSample, rate: GraphSampleRate) -> Option<MeasurementSample> {
         let vbus_uv = sample.vbus.get::<microvolt>().round() as i64;
         let ibus_ua = sample.ibus.get::<microampere>().round() as i64;
         let power_uw = sample.power.get::<microwatt>().round() as i64;
@@ -66,6 +71,16 @@ impl MeasurementAccumulator {
             let missing = rate.missing_samples(previous.sequence, sample.sequence);
             (missing, delta_ticks * MICROSECONDS_PER_MILLISECOND)
         });
+
+        if let Some(previous) = self.previous {
+            let delta_ticks = sample.sequence.wrapping_sub(previous.sequence);
+            if delta_ticks == 0 || delta_ticks > MAX_FORWARD_SEQUENCE_TICKS || delta_ticks % rate.sequence_step() != 0 {
+                self.cumulative_discarded_sequence_samples =
+                    self.cumulative_discarded_sequence_samples.saturating_add(1);
+                self.pending_discarded_sequence_samples = self.pending_discarded_sequence_samples.saturating_add(1);
+                return None;
+            }
+        }
         let gap_duration_us = u64::from(missing_samples) * expected_ticks * MICROSECONDS_PER_MILLISECOND;
 
         if let Some(previous) = self.previous {
@@ -88,6 +103,8 @@ impl MeasurementAccumulator {
             interpolated: missing_samples > 0,
             cumulative_missing_samples: self.cumulative_missing_samples,
             cumulative_interpolated_duration_us: self.cumulative_interpolated_duration_us,
+            discarded_sequence_samples: self.pending_discarded_sequence_samples,
+            cumulative_discarded_sequence_samples: self.cumulative_discarded_sequence_samples,
             vbus_uv,
             ibus_ua,
             power_uw,
@@ -105,7 +122,8 @@ impl MeasurementAccumulator {
             power_uw,
         });
         self.sample_index += 1;
-        decoded
+        self.pending_discarded_sequence_samples = 0;
+        Some(decoded)
     }
 
     pub(crate) fn reset_continuity(&mut self) {
@@ -114,6 +132,10 @@ impl MeasurementAccumulator {
 
     pub(crate) fn reset(&mut self) {
         *self = Self::default();
+    }
+
+    pub(crate) const fn cumulative_discarded_sequence_samples(&self) -> u64 {
+        self.cumulative_discarded_sequence_samples
     }
 }
 
@@ -230,8 +252,8 @@ mod tests {
     #[test]
     fn integrates_charge_and_energy_from_device_time() {
         let mut accumulator = MeasurementAccumulator::default();
-        accumulator.push(sample(0, 10.0, 2.0), GraphSampleRate::Sps2);
-        let second = accumulator.push(sample(500, 10.0, 2.0), GraphSampleRate::Sps2);
+        accumulator.push(sample(0, 10.0, 2.0), GraphSampleRate::Sps2).unwrap();
+        let second = accumulator.push(sample(500, 10.0, 2.0), GraphSampleRate::Sps2).unwrap();
 
         assert_eq!(second.elapsed_us, 500_000);
         assert!((second.charge_uah - 277.777_777).abs() < 0.000_001);
@@ -242,8 +264,8 @@ mod tests {
     #[test]
     fn interpolates_across_gaps_and_records_their_quality() {
         let mut accumulator = MeasurementAccumulator::default();
-        accumulator.push(sample(0, 10.0, 1.0), GraphSampleRate::Sps50);
-        let after_gap = accumulator.push(sample(60, 10.0, 3.0), GraphSampleRate::Sps50);
+        accumulator.push(sample(0, 10.0, 1.0), GraphSampleRate::Sps50).unwrap();
+        let after_gap = accumulator.push(sample(60, 10.0, 3.0), GraphSampleRate::Sps50).unwrap();
 
         assert_eq!(after_gap.missing_samples, 2);
         assert_eq!(after_gap.gap_duration_us, 40_000);
@@ -256,11 +278,50 @@ mod tests {
     #[test]
     fn signed_and_absolute_metrics_are_distinct() {
         let mut accumulator = MeasurementAccumulator::default();
-        let measurement = accumulator.push(sample(0, 5.0, -2.0), GraphSampleRate::Sps10);
+        let measurement = accumulator.push(sample(0, 5.0, -2.0), GraphSampleRate::Sps10).unwrap();
 
         assert_eq!(PlotMetric::Current.value(&measurement), 2.0);
         assert_eq!(PlotMetric::SignedCurrent.value(&measurement), -2.0);
         assert_eq!(PlotMetric::Power.value(&measurement), 10.0);
         assert_eq!(PlotMetric::SignedPower.value(&measurement), -10.0);
+    }
+
+    #[test]
+    fn discards_duplicate_and_out_of_order_sequence_samples() {
+        let mut accumulator = MeasurementAccumulator::default();
+        accumulator
+            .push(sample(1_000, 5.0, 1.0), GraphSampleRate::Sps1000)
+            .unwrap();
+
+        assert!(
+            accumulator
+                .push(sample(1_000, 50.0, 10.0), GraphSampleRate::Sps1000)
+                .is_none()
+        );
+        assert!(
+            accumulator
+                .push(sample(990, 50.0, 10.0), GraphSampleRate::Sps1000)
+                .is_none()
+        );
+
+        let next = accumulator
+            .push(sample(1_001, 5.0, 1.0), GraphSampleRate::Sps1000)
+            .unwrap();
+        assert_eq!(next.elapsed_us, 1_000);
+        assert_eq!(next.discarded_sequence_samples, 2);
+        assert_eq!(next.cumulative_discarded_sequence_samples, 2);
+        assert!((next.charge_uah - 0.277_777).abs() < 0.000_001);
+    }
+
+    #[test]
+    fn accepts_sequence_counter_rollover() {
+        let mut accumulator = MeasurementAccumulator::default();
+        accumulator
+            .push(sample(u16::MAX, 5.0, 1.0), GraphSampleRate::Sps1000)
+            .unwrap();
+        let after_rollover = accumulator.push(sample(0, 5.0, 1.0), GraphSampleRate::Sps1000).unwrap();
+
+        assert_eq!(after_rollover.elapsed_us, 1_000);
+        assert_eq!(after_rollover.cumulative_discarded_sequence_samples, 0);
     }
 }

--- a/km003c-egui/src/pd_decoder.rs
+++ b/km003c-egui/src/pd_decoder.rs
@@ -26,6 +26,7 @@ pub enum PdCategory {
 /// A single decoded PD log entry for display.
 #[derive(Debug, Clone)]
 pub struct DecodedPdEntry {
+    pub timestamp_seconds: f64,
     pub category: PdCategory,
     pub summary: String,
     pub details: Vec<String>,
@@ -47,11 +48,13 @@ impl PdDecoder {
         let decoded = self.session.decode_event(event);
         vec![match decoded {
             DecodedPdEvent::Connect { timestamp } => DecodedPdEntry {
+                timestamp_seconds: timestamp.get::<millisecond>() / 1000.0,
                 category: PdCategory::Connect,
                 summary: format!("[{:.3}s] ** CONNECT **", timestamp.get::<millisecond>() / 1000.0),
                 details: vec![],
             },
             DecodedPdEvent::Disconnect { timestamp } => DecodedPdEntry {
+                timestamp_seconds: timestamp.get::<millisecond>() / 1000.0,
                 category: PdCategory::Disconnect,
                 summary: format!("[{:.3}s] ** DISCONNECT **", timestamp.get::<millisecond>() / 1000.0),
                 details: vec![],
@@ -65,6 +68,7 @@ impl PdDecoder {
     fn format_message(&self, decoded: &DecodedPdMessage) -> DecodedPdEntry {
         let message = &decoded.message;
         let message_type = message.header.message_type();
+        let timestamp_seconds = decoded.timestamp.get::<millisecond>() / 1000.0;
         let summary = format!(
             "[{:.3}s] SOP{}: {:?} (ID={}, ROLE={:?}/{:?})",
             decoded.timestamp.get::<millisecond>() / 1000.0,
@@ -77,36 +81,43 @@ impl PdDecoder {
 
         match &message.payload {
             Some(Payload::Data(Data::SourceCapabilities(capabilities))) => DecodedPdEntry {
+                timestamp_seconds,
                 category: PdCategory::SourceCaps,
                 summary,
                 details: format_capabilities(capabilities.pdos(), "SPR Source Capabilities"),
             },
             Some(Payload::Data(Data::Request(request))) => DecodedPdEntry {
+                timestamp_seconds,
                 category: PdCategory::Request,
                 summary,
                 details: format_request(request, self.session.source_capabilities()),
             },
             Some(Payload::Data(Data::EprMode(mode))) => DecodedPdEntry {
+                timestamp_seconds,
                 category: PdCategory::Extended,
                 summary,
                 details: vec![format!("EPR Mode: {mode:?}")],
             },
             Some(Payload::Data(Data::Unknown)) => DecodedPdEntry {
+                timestamp_seconds,
                 category: PdCategory::Control,
                 summary,
                 details: vec!["Unknown Data Message".to_string()],
             },
             Some(Payload::Data(data)) => DecodedPdEntry {
+                timestamp_seconds,
                 category: PdCategory::Control,
                 summary,
                 details: vec![format!("Data: {data:?}")],
             },
             Some(Payload::Extended(Extended::EprSourceCapabilities(pdos))) => DecodedPdEntry {
+                timestamp_seconds,
                 category: PdCategory::Extended,
                 summary,
                 details: format_capabilities(pdos.as_slice(), "EPR Source Capabilities"),
             },
             Some(Payload::Extended(Extended::ExtendedControl(control))) => DecodedPdEntry {
+                timestamp_seconds,
                 category: PdCategory::Extended,
                 summary,
                 details: vec![format!(
@@ -116,11 +127,13 @@ impl PdDecoder {
                 )],
             },
             Some(Payload::Extended(extended)) => DecodedPdEntry {
+                timestamp_seconds,
                 category: PdCategory::Extended,
                 summary,
                 details: vec![format!("Extended: {extended:?}")],
             },
             None => DecodedPdEntry {
+                timestamp_seconds,
                 category: PdCategory::Control,
                 summary,
                 details: vec![],
@@ -157,6 +170,7 @@ fn format_chunk_status(status: PdChunkStatus) -> DecodedPdEntry {
     };
 
     DecodedPdEntry {
+        timestamp_seconds: timestamp,
         category: PdCategory::Extended,
         summary,
         details: vec![],
@@ -164,7 +178,9 @@ fn format_chunk_status(status: PdChunkStatus) -> DecodedPdEntry {
 }
 
 fn format_failure(failure: PdDecodeFailure) -> DecodedPdEntry {
+    let timestamp_seconds = failure.timestamp.get::<millisecond>() / 1000.0;
     DecodedPdEntry {
+        timestamp_seconds,
         category: PdCategory::Error,
         summary: format!(
             "[{:.3}s] SOP{}: Parse error: {}",

--- a/km003c-egui/src/pd_trace_view.rs
+++ b/km003c-egui/src/pd_trace_view.rs
@@ -1,0 +1,106 @@
+use km003c_lib::uom::si::time::second;
+use km003c_lib::{PdProtocolTraceEventKind, PdTrace, PdTypeCState};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PdTraceCategory {
+    TypeCState,
+    ProtocolEvent,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PdTraceEntry {
+    pub(crate) timestamp_seconds: f64,
+    pub(crate) category: PdTraceCategory,
+    pub(crate) summary: String,
+}
+
+pub(crate) fn decode_trace(trace: &PdTrace) -> Vec<PdTraceEntry> {
+    let mut entries = Vec::with_capacity(trace.state_events.len() + trace.protocol_events.len());
+
+    entries.extend(trace.state_events.iter().map(|event| {
+        let code = u8::from(event.state);
+        let (category, label) = match event.state {
+            PdTypeCState::Unknown(_) => (PdTraceCategory::Unknown, format!("Unknown state 0x{code:02x}")),
+            state => (PdTraceCategory::TypeCState, format!("{state:?} (0x{code:02x})")),
+        };
+
+        PdTraceEntry {
+            timestamp_seconds: event.timestamp.get::<second>(),
+            category,
+            summary: format!(
+                "[uptime {:>8.0}s] Type-C state: {label}",
+                event.timestamp.get::<second>(),
+            ),
+        }
+    }));
+
+    entries.extend(trace.protocol_events.iter().map(|event| {
+        let code = u8::from(event.kind);
+        let (category, label) = match event.kind {
+            PdProtocolTraceEventKind::Unknown(_) => (PdTraceCategory::Unknown, format!("Unknown state 0x{code:02x}")),
+            kind => (PdTraceCategory::ProtocolEvent, format!("{kind:?} (0x{code:02x})")),
+        };
+
+        PdTraceEntry {
+            timestamp_seconds: event.timestamp.get::<second>(),
+            category,
+            summary: format!(
+                "[uptime {:>8.0}s] Protocol trace: {label}",
+                event.timestamp.get::<second>(),
+            ),
+        }
+    }));
+
+    entries.sort_by(|left, right| left.timestamp_seconds.total_cmp(&right.timestamp_seconds));
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use km003c_lib::uom::si::f64::Time;
+    use km003c_lib::{PdTraceProtocolEvent, PdTraceStateEvent};
+
+    #[test]
+    fn combines_trace_queues_in_timestamp_order() {
+        let trace = PdTrace {
+            state_events: vec![PdTraceStateEvent {
+                state: PdTypeCState::AttachedSink,
+                timestamp: Time::new::<second>(12.0),
+            }],
+            protocol_events: vec![PdTraceProtocolEvent {
+                kind: PdProtocolTraceEventKind::ReceivedMessage,
+                timestamp: Time::new::<second>(10.0),
+            }],
+        };
+
+        let entries = decode_trace(&trace);
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].category, PdTraceCategory::ProtocolEvent);
+        assert!(entries[0].summary.contains("ReceivedMessage (0x82)"));
+        assert_eq!(entries[1].category, PdTraceCategory::TypeCState);
+        assert!(entries[1].summary.contains("AttachedSink (0x17)"));
+    }
+
+    #[test]
+    fn preserves_unknown_codes_in_display() {
+        let trace = PdTrace {
+            state_events: vec![PdTraceStateEvent {
+                state: PdTypeCState::Unknown(0xfe),
+                timestamp: Time::new::<second>(1.0),
+            }],
+            protocol_events: vec![PdTraceProtocolEvent {
+                kind: PdProtocolTraceEventKind::Unknown(0x76),
+                timestamp: Time::new::<second>(2.0),
+            }],
+        };
+
+        let entries = decode_trace(&trace);
+
+        assert!(entries.iter().all(|entry| entry.category == PdTraceCategory::Unknown));
+        assert!(entries[0].summary.contains("Unknown state 0xfe"));
+        assert!(entries[1].summary.contains("Unknown state 0x76"));
+    }
+}

--- a/km003c-egui/src/recording.rs
+++ b/km003c-egui/src/recording.rs
@@ -52,6 +52,7 @@ struct RecordingOrigin {
     energy_uwh: f64,
     cumulative_missing_samples: u64,
     cumulative_interpolated_duration_us: u64,
+    cumulative_discarded_sequence_samples: u64,
 }
 
 impl From<Option<MeasurementSample>> for RecordingOrigin {
@@ -63,6 +64,7 @@ impl From<Option<MeasurementSample>> for RecordingOrigin {
                 energy_uwh: 0.0,
                 cumulative_missing_samples: 0,
                 cumulative_interpolated_duration_us: 0,
+                cumulative_discarded_sequence_samples: 0,
             },
             |sample| Self {
                 elapsed_us: sample.elapsed_us,
@@ -70,6 +72,7 @@ impl From<Option<MeasurementSample>> for RecordingOrigin {
                 energy_uwh: sample.energy_uwh,
                 cumulative_missing_samples: sample.cumulative_missing_samples,
                 cumulative_interpolated_duration_us: sample.cumulative_interpolated_duration_us,
+                cumulative_discarded_sequence_samples: sample.cumulative_discarded_sequence_samples,
             },
         )
     }
@@ -87,6 +90,8 @@ struct RecordingRow {
     interpolated: bool,
     cumulative_missing_samples: u64,
     cumulative_interpolated_duration_us: u64,
+    discarded_sequence_samples: u32,
+    cumulative_discarded_sequence_samples: u64,
     vbus_uv: i64,
     ibus_ua: i64,
     power_uw: i64,
@@ -115,6 +120,10 @@ impl RecordingRow {
             cumulative_interpolated_duration_us: sample
                 .cumulative_interpolated_duration_us
                 .saturating_sub(origin.cumulative_interpolated_duration_us),
+            discarded_sequence_samples: sample.discarded_sequence_samples,
+            cumulative_discarded_sequence_samples: sample
+                .cumulative_discarded_sequence_samples
+                .saturating_sub(origin.cumulative_discarded_sequence_samples),
             vbus_uv: sample.vbus_uv,
             ibus_ua: sample.ibus_ua,
             power_uw: sample.power_uw,
@@ -147,6 +156,7 @@ pub(crate) struct RecordingSummary {
     pub(crate) elapsed_us: u64,
     pub(crate) missing_samples: u64,
     pub(crate) interpolated_duration_us: u64,
+    pub(crate) discarded_sequence_samples: u64,
 }
 
 impl RecordingSummary {
@@ -172,6 +182,7 @@ pub(crate) struct Recorder {
     pub(crate) elapsed_us: u64,
     pub(crate) missing_samples: u64,
     pub(crate) interpolated_duration_us: u64,
+    pub(crate) discarded_sequence_samples: u64,
 }
 
 impl Recorder {
@@ -224,6 +235,7 @@ impl Recorder {
             elapsed_us: 0,
             missing_samples: 0,
             interpolated_duration_us: 0,
+            discarded_sequence_samples: 0,
         })
     }
 
@@ -249,6 +261,7 @@ impl Recorder {
                     self.elapsed_us = last.elapsed_us;
                     self.missing_samples = last.cumulative_missing_samples;
                     self.interpolated_duration_us = last.cumulative_interpolated_duration_us;
+                    self.discarded_sequence_samples = last.cumulative_discarded_sequence_samples;
                 }
                 Ok(())
             }
@@ -392,6 +405,7 @@ where
         elapsed_us: 0,
         missing_samples: 0,
         interpolated_duration_us: 0,
+        discarded_sequence_samples: 0,
     };
 
     loop {
@@ -402,6 +416,7 @@ where
                     summary.elapsed_us = last.elapsed_us;
                     summary.missing_samples = last.cumulative_missing_samples;
                     summary.interpolated_duration_us = last.cumulative_interpolated_duration_us;
+                    summary.discarded_sequence_samples = last.cumulative_discarded_sequence_samples;
                 }
                 buffered.append(&mut rows);
                 if buffered.len() >= ROW_GROUP_SIZE {
@@ -431,6 +446,8 @@ fn rows_to_dataframe(rows: &[RecordingRow]) -> Result<DataFrame, polars::error::
         "interpolated" => rows.iter().map(|row| row.interpolated).collect::<Vec<_>>(),
         "cumulative_missing_samples" => rows.iter().map(|row| row.cumulative_missing_samples).collect::<Vec<_>>(),
         "cumulative_interpolated_duration_us" => rows.iter().map(|row| row.cumulative_interpolated_duration_us).collect::<Vec<_>>(),
+        "discarded_sequence_samples" => rows.iter().map(|row| row.discarded_sequence_samples).collect::<Vec<_>>(),
+        "cumulative_discarded_sequence_samples" => rows.iter().map(|row| row.cumulative_discarded_sequence_samples).collect::<Vec<_>>(),
         "vbus_uv" => rows.iter().map(|row| row.vbus_uv).collect::<Vec<_>>(),
         "ibus_ua" => rows.iter().map(|row| row.ibus_ua).collect::<Vec<_>>(),
         "power_uw" => rows.iter().map(|row| row.power_uw).collect::<Vec<_>>(),
@@ -459,8 +476,14 @@ fn replace_file(partial: &Path, final_path: &Path) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use polars::prelude::{CsvReader, ParquetReader, SerReader};
+    use crate::measurement::MeasurementAccumulator;
+    use km003c_lib::{
+        DeviceConfig, GraphSampleRate, KM003C,
+        packet::{Attribute, AttributeSet},
+    };
+    use polars::prelude::{ChunkAgg, CsvReader, ParquetReader, SerReader};
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{Duration, Instant};
 
     static NEXT_TEST_FILE: AtomicU64 = AtomicU64::new(0);
 
@@ -476,6 +499,8 @@ mod tests {
             interpolated: missing > 0,
             cumulative_missing_samples: missing,
             cumulative_interpolated_duration_us: interpolated_us,
+            discarded_sequence_samples: 0,
+            cumulative_discarded_sequence_samples: 0,
             vbus_uv: 5_000_000,
             ibus_ua: -1_000_000,
             power_uw: -5_000_000,
@@ -508,6 +533,7 @@ mod tests {
             elapsed_us: 1_000_000,
             missing_samples: 2,
             interpolated_duration_us: 10_000,
+            discarded_sequence_samples: 0,
         };
         assert_eq!(summary.completeness_percent(), 99.0);
     }
@@ -518,7 +544,7 @@ mod tests {
         let dataframe = rows_to_dataframe(&[row]).unwrap();
 
         assert_eq!(dataframe.height(), 1);
-        assert_eq!(dataframe.width(), 19);
+        assert_eq!(dataframe.width(), 21);
         assert_eq!(
             dataframe.column("vbus_uv").unwrap().i64().unwrap().get(0),
             Some(5_000_000)
@@ -532,7 +558,7 @@ mod tests {
         let dataframe = ParquetReader::new(File::open(&path).unwrap()).finish().unwrap();
 
         assert_eq!(summary.rows, 2);
-        assert_eq!(dataframe.shape(), (2, 19));
+        assert_eq!(dataframe.shape(), (2, 21));
         assert_eq!(
             dataframe.column("elapsed_us").unwrap().u64().unwrap().get(1),
             Some(20_000)
@@ -547,12 +573,123 @@ mod tests {
         let dataframe = CsvReader::new(File::open(&path).unwrap()).finish().unwrap();
 
         assert_eq!(summary.rows, 2);
-        assert_eq!(dataframe.shape(), (2, 19));
+        assert_eq!(dataframe.shape(), (2, 21));
         assert_eq!(
             dataframe.column("vbus_uv").unwrap().i64().unwrap().get(0),
             Some(5_000_000)
         );
         std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    #[ignore = "requires a connected KM003C"]
+    fn records_live_adcqueue_to_parquet() {
+        tokio::runtime::Runtime::new().unwrap().block_on(async {
+            let mut device = KM003C::new(DeviceConfig::vendor()).await.unwrap();
+            let state = device.state().unwrap();
+            let metadata = RecordingMetadata {
+                model: state.info.model.clone(),
+                firmware: state.info.fw_version.clone(),
+                serial: state.info.serial_id.clone(),
+            };
+            let path = test_path("hardware.parquet");
+            let mut recorder = Recorder::start(path.clone(), RecordingFormat::Parquet, metadata, None).unwrap();
+            let rate = GraphSampleRate::Sps1000;
+            let mut accumulator = MeasurementAccumulator::default();
+            let mut recorded = 0_u64;
+
+            device.start_graph_mode(rate).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while recorded < 1_500 && Instant::now() < deadline {
+                let packet = device
+                    .request_data(AttributeSet::single(Attribute::AdcQueue))
+                    .await
+                    .unwrap();
+                let Some(queue) = packet.get_adc_queue() else {
+                    continue;
+                };
+                let measurements = queue
+                    .samples
+                    .iter()
+                    .copied()
+                    .filter_map(|sample| accumulator.push(sample, rate))
+                    .collect::<Vec<_>>();
+                recorder.push(&measurements).unwrap();
+                recorded += measurements.len() as u64;
+            }
+            device.stop_graph_mode().await.unwrap();
+            assert!(
+                recorded >= 1_500,
+                "received only {recorded} samples before the deadline"
+            );
+
+            recorder.request_finish().unwrap();
+            let summary = loop {
+                match recorder.poll_event() {
+                    Some(RecordingEvent::Finished(summary)) => break summary,
+                    Some(event) => panic!("recording failed: {event:?}"),
+                    None if Instant::now() < deadline + Duration::from_secs(5) => {
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                    None => panic!("recording did not finish before the deadline"),
+                }
+            };
+
+            let dataframe = ParquetReader::new(File::open(&path).unwrap()).finish().unwrap();
+            assert_eq!(summary.rows, recorded);
+            assert_eq!(dataframe.shape(), (recorded as usize, 21));
+            assert!(dataframe.column("vbus_uv").unwrap().i64().unwrap().min().unwrap() > 0);
+            assert_eq!(
+                dataframe.column("sample_rate_hz").unwrap().u32().unwrap().min(),
+                Some(1_000)
+            );
+            for column in ["vbus_uv", "ibus_ua", "power_uw", "cc1_uv", "cc2_uv", "dp_uv", "dm_uv"] {
+                assert_eq!(
+                    dataframe.column(column).unwrap().null_count(),
+                    0,
+                    "{column} contains nulls"
+                );
+            }
+
+            let elapsed = dataframe.column("elapsed_us").unwrap().u64().unwrap();
+            let current = dataframe.column("ibus_ua").unwrap().i64().unwrap();
+            let power = dataframe.column("power_uw").unwrap().i64().unwrap();
+            let mut expected_charge_uah = 0.0;
+            let mut expected_energy_uwh = 0.0;
+            for index in 1..dataframe.height() {
+                let delta_us = (elapsed.get(index).unwrap() - elapsed.get(index - 1).unwrap()) as f64;
+                expected_charge_uah +=
+                    (current.get(index - 1).unwrap() + current.get(index).unwrap()) as f64 * delta_us / 7_200_000_000.0;
+                expected_energy_uwh +=
+                    (power.get(index - 1).unwrap() + power.get(index).unwrap()) as f64 * delta_us / 7_200_000_000.0;
+            }
+            let last = dataframe.height() - 1;
+            let charge_uah = dataframe
+                .column("charge_uah")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(last)
+                .unwrap();
+            let energy_uwh = dataframe
+                .column("energy_uwh")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(last)
+                .unwrap();
+            assert!((charge_uah - expected_charge_uah).abs() < 1e-9);
+            assert!((energy_uwh - expected_energy_uwh).abs() < 1e-9);
+            println!(
+                "recorded={} missing={} discarded={} completeness={:.6}% charge={charge_uah:.6} uAh energy={energy_uwh:.6} uWh",
+                summary.rows,
+                summary.missing_samples,
+                summary.discarded_sequence_samples,
+                summary.completeness_percent()
+            );
+            std::fs::remove_file(path).unwrap();
+        });
     }
 
     fn write_test_recording(path: &Path, format: RecordingFormat) -> RecordingSummary {

--- a/km003c-egui/src/recording.rs
+++ b/km003c-egui/src/recording.rs
@@ -50,6 +50,8 @@ struct RecordingOrigin {
     elapsed_us: u64,
     charge_uah: f64,
     energy_uwh: f64,
+    charge_throughput_uah: f64,
+    energy_throughput_uwh: f64,
     cumulative_missing_samples: u64,
     cumulative_interpolated_duration_us: u64,
     cumulative_discarded_sequence_samples: u64,
@@ -62,6 +64,8 @@ impl From<Option<MeasurementSample>> for RecordingOrigin {
                 elapsed_us: 0,
                 charge_uah: 0.0,
                 energy_uwh: 0.0,
+                charge_throughput_uah: 0.0,
+                energy_throughput_uwh: 0.0,
                 cumulative_missing_samples: 0,
                 cumulative_interpolated_duration_us: 0,
                 cumulative_discarded_sequence_samples: 0,
@@ -70,6 +74,8 @@ impl From<Option<MeasurementSample>> for RecordingOrigin {
                 elapsed_us: sample.elapsed_us,
                 charge_uah: sample.charge_uah,
                 energy_uwh: sample.energy_uwh,
+                charge_throughput_uah: sample.charge_throughput_uah,
+                energy_throughput_uwh: sample.energy_throughput_uwh,
                 cumulative_missing_samples: sample.cumulative_missing_samples,
                 cumulative_interpolated_duration_us: sample.cumulative_interpolated_duration_us,
                 cumulative_discarded_sequence_samples: sample.cumulative_discarded_sequence_samples,
@@ -97,6 +103,8 @@ struct RecordingRow {
     power_uw: i64,
     charge_uah: f64,
     energy_uwh: f64,
+    charge_throughput_uah: f64,
+    energy_throughput_uwh: f64,
     cc1_uv: i64,
     cc2_uv: i64,
     dp_uv: i64,
@@ -129,6 +137,8 @@ impl RecordingRow {
             power_uw: sample.power_uw,
             charge_uah: sample.charge_uah - origin.charge_uah,
             energy_uwh: sample.energy_uwh - origin.energy_uwh,
+            charge_throughput_uah: sample.charge_throughput_uah - origin.charge_throughput_uah,
+            energy_throughput_uwh: sample.energy_throughput_uwh - origin.energy_throughput_uwh,
             cc1_uv: sample.cc1_uv,
             cc2_uv: sample.cc2_uv,
             dp_uv: sample.dp_uv,
@@ -453,6 +463,8 @@ fn rows_to_dataframe(rows: &[RecordingRow]) -> Result<DataFrame, polars::error::
         "power_uw" => rows.iter().map(|row| row.power_uw).collect::<Vec<_>>(),
         "charge_uah" => rows.iter().map(|row| row.charge_uah).collect::<Vec<_>>(),
         "energy_uwh" => rows.iter().map(|row| row.energy_uwh).collect::<Vec<_>>(),
+        "charge_throughput_uah" => rows.iter().map(|row| row.charge_throughput_uah).collect::<Vec<_>>(),
+        "energy_throughput_uwh" => rows.iter().map(|row| row.energy_throughput_uwh).collect::<Vec<_>>(),
         "cc1_uv" => rows.iter().map(|row| row.cc1_uv).collect::<Vec<_>>(),
         "cc2_uv" => rows.iter().map(|row| row.cc2_uv).collect::<Vec<_>>(),
         "dp_uv" => rows.iter().map(|row| row.dp_uv).collect::<Vec<_>>(),
@@ -506,6 +518,8 @@ mod tests {
             power_uw: -5_000_000,
             charge_uah: -100.0,
             energy_uwh: -500.0,
+            charge_throughput_uah: 100.0,
+            energy_throughput_uwh: 500.0,
             cc1_uv: 1_000_000,
             cc2_uv: 0,
             dp_uv: 600_000,
@@ -544,7 +558,7 @@ mod tests {
         let dataframe = rows_to_dataframe(&[row]).unwrap();
 
         assert_eq!(dataframe.height(), 1);
-        assert_eq!(dataframe.width(), 21);
+        assert_eq!(dataframe.width(), 23);
         assert_eq!(
             dataframe.column("vbus_uv").unwrap().i64().unwrap().get(0),
             Some(5_000_000)
@@ -558,7 +572,7 @@ mod tests {
         let dataframe = ParquetReader::new(File::open(&path).unwrap()).finish().unwrap();
 
         assert_eq!(summary.rows, 2);
-        assert_eq!(dataframe.shape(), (2, 21));
+        assert_eq!(dataframe.shape(), (2, 23));
         assert_eq!(
             dataframe.column("elapsed_us").unwrap().u64().unwrap().get(1),
             Some(20_000)
@@ -573,7 +587,7 @@ mod tests {
         let dataframe = CsvReader::new(File::open(&path).unwrap()).finish().unwrap();
 
         assert_eq!(summary.rows, 2);
-        assert_eq!(dataframe.shape(), (2, 21));
+        assert_eq!(dataframe.shape(), (2, 23));
         assert_eq!(
             dataframe.column("vbus_uv").unwrap().i64().unwrap().get(0),
             Some(5_000_000)
@@ -638,7 +652,7 @@ mod tests {
 
             let dataframe = ParquetReader::new(File::open(&path).unwrap()).finish().unwrap();
             assert_eq!(summary.rows, recorded);
-            assert_eq!(dataframe.shape(), (recorded as usize, 21));
+            assert_eq!(dataframe.shape(), (recorded as usize, 23));
             assert!(dataframe.column("vbus_uv").unwrap().i64().unwrap().min().unwrap() > 0);
             assert_eq!(
                 dataframe.column("sample_rate_hz").unwrap().u32().unwrap().min(),
@@ -657,12 +671,20 @@ mod tests {
             let power = dataframe.column("power_uw").unwrap().i64().unwrap();
             let mut expected_charge_uah = 0.0;
             let mut expected_energy_uwh = 0.0;
+            let mut expected_charge_throughput_uah = 0.0;
+            let mut expected_energy_throughput_uwh = 0.0;
             for index in 1..dataframe.height() {
                 let delta_us = (elapsed.get(index).unwrap() - elapsed.get(index - 1).unwrap()) as f64;
                 expected_charge_uah +=
                     (current.get(index - 1).unwrap() + current.get(index).unwrap()) as f64 * delta_us / 7_200_000_000.0;
                 expected_energy_uwh +=
                     (power.get(index - 1).unwrap() + power.get(index).unwrap()) as f64 * delta_us / 7_200_000_000.0;
+                expected_charge_throughput_uah +=
+                    (current.get(index - 1).unwrap().abs() + current.get(index).unwrap().abs()) as f64 * delta_us
+                        / 7_200_000_000.0;
+                expected_energy_throughput_uwh +=
+                    (power.get(index - 1).unwrap().abs() + power.get(index).unwrap().abs()) as f64 * delta_us
+                        / 7_200_000_000.0;
             }
             let last = dataframe.height() - 1;
             let charge_uah = dataframe
@@ -679,8 +701,24 @@ mod tests {
                 .unwrap()
                 .get(last)
                 .unwrap();
+            let charge_throughput_uah = dataframe
+                .column("charge_throughput_uah")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(last)
+                .unwrap();
+            let energy_throughput_uwh = dataframe
+                .column("energy_throughput_uwh")
+                .unwrap()
+                .f64()
+                .unwrap()
+                .get(last)
+                .unwrap();
             assert!((charge_uah - expected_charge_uah).abs() < 1e-9);
             assert!((energy_uwh - expected_energy_uwh).abs() < 1e-9);
+            assert!((charge_throughput_uah - expected_charge_throughput_uah).abs() < 1e-9);
+            assert!((energy_throughput_uwh - expected_energy_throughput_uwh).abs() < 1e-9);
             println!(
                 "recorded={} missing={} discarded={} completeness={:.6}% charge={charge_uah:.6} uAh energy={energy_uwh:.6} uWh",
                 summary.rows,

--- a/km003c-egui/src/recording.rs
+++ b/km003c-egui/src/recording.rs
@@ -1,0 +1,587 @@
+use std::error::Error;
+use std::fs::File;
+use std::io::BufWriter;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError, TrySendError};
+use std::thread::{self, JoinHandle};
+
+use polars::df;
+use polars::prelude::{CsvWriter, DataFrame, KeyValueMetadata, ParquetWriter, SerWriter};
+
+use crate::measurement::MeasurementSample;
+
+const RECORDING_SCHEMA_VERSION: &str = "1";
+const ROW_GROUP_SIZE: usize = 8_192;
+const CHANNEL_CAPACITY: usize = 32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RecordingFormat {
+    Parquet,
+    Csv,
+}
+
+impl RecordingFormat {
+    pub(crate) const ALL: [Self; 2] = [Self::Parquet, Self::Csv];
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Parquet => "Parquet",
+            Self::Csv => "CSV",
+        }
+    }
+
+    pub(crate) const fn extension(self) -> &'static str {
+        match self {
+            Self::Parquet => "parquet",
+            Self::Csv => "csv",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RecordingMetadata {
+    pub(crate) model: String,
+    pub(crate) firmware: String,
+    pub(crate) serial: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RecordingOrigin {
+    elapsed_us: u64,
+    charge_uah: f64,
+    energy_uwh: f64,
+    cumulative_missing_samples: u64,
+    cumulative_interpolated_duration_us: u64,
+}
+
+impl From<Option<MeasurementSample>> for RecordingOrigin {
+    fn from(sample: Option<MeasurementSample>) -> Self {
+        sample.map_or(
+            Self {
+                elapsed_us: 0,
+                charge_uah: 0.0,
+                energy_uwh: 0.0,
+                cumulative_missing_samples: 0,
+                cumulative_interpolated_duration_us: 0,
+            },
+            |sample| Self {
+                elapsed_us: sample.elapsed_us,
+                charge_uah: sample.charge_uah,
+                energy_uwh: sample.energy_uwh,
+                cumulative_missing_samples: sample.cumulative_missing_samples,
+                cumulative_interpolated_duration_us: sample.cumulative_interpolated_duration_us,
+            },
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct RecordingRow {
+    elapsed_us: u64,
+    sample_index: u64,
+    sequence: u32,
+    marker: u32,
+    sample_rate_hz: u32,
+    missing_samples: u32,
+    gap_duration_us: u64,
+    interpolated: bool,
+    cumulative_missing_samples: u64,
+    cumulative_interpolated_duration_us: u64,
+    vbus_uv: i64,
+    ibus_ua: i64,
+    power_uw: i64,
+    charge_uah: f64,
+    energy_uwh: f64,
+    cc1_uv: i64,
+    cc2_uv: i64,
+    dp_uv: i64,
+    dm_uv: i64,
+}
+
+impl RecordingRow {
+    fn from_sample(sample: MeasurementSample, origin: RecordingOrigin, sample_index: u64) -> Self {
+        Self {
+            elapsed_us: sample.elapsed_us.saturating_sub(origin.elapsed_us),
+            sample_index,
+            sequence: u32::from(sample.sequence),
+            marker: u32::from(sample.marker),
+            sample_rate_hz: u32::from(sample.sample_rate_hz),
+            missing_samples: u32::from(sample.missing_samples),
+            gap_duration_us: sample.gap_duration_us,
+            interpolated: sample.interpolated,
+            cumulative_missing_samples: sample
+                .cumulative_missing_samples
+                .saturating_sub(origin.cumulative_missing_samples),
+            cumulative_interpolated_duration_us: sample
+                .cumulative_interpolated_duration_us
+                .saturating_sub(origin.cumulative_interpolated_duration_us),
+            vbus_uv: sample.vbus_uv,
+            ibus_ua: sample.ibus_ua,
+            power_uw: sample.power_uw,
+            charge_uah: sample.charge_uah - origin.charge_uah,
+            energy_uwh: sample.energy_uwh - origin.energy_uwh,
+            cc1_uv: sample.cc1_uv,
+            cc2_uv: sample.cc2_uv,
+            dp_uv: sample.dp_uv,
+            dm_uv: sample.dm_uv,
+        }
+    }
+}
+
+enum WriterCommand {
+    Rows(Vec<RecordingRow>),
+    Finish,
+}
+
+#[derive(Debug)]
+pub(crate) enum RecordingEvent {
+    Finished(RecordingSummary),
+    Interrupted(RecordingSummary, String),
+    Failed(String),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RecordingSummary {
+    pub(crate) path: PathBuf,
+    pub(crate) rows: u64,
+    pub(crate) elapsed_us: u64,
+    pub(crate) missing_samples: u64,
+    pub(crate) interpolated_duration_us: u64,
+}
+
+impl RecordingSummary {
+    pub(crate) fn completeness_percent(&self) -> f64 {
+        if self.elapsed_us == 0 {
+            100.0
+        } else {
+            (1.0 - self.interpolated_duration_us as f64 / self.elapsed_us as f64).max(0.0) * 100.0
+        }
+    }
+}
+
+pub(crate) struct Recorder {
+    command_tx: SyncSender<WriterCommand>,
+    event_rx: Receiver<RecordingEvent>,
+    handle: Option<JoinHandle<()>>,
+    origin: RecordingOrigin,
+    next_sample_index: u64,
+    finishing: bool,
+    interrupted: Option<String>,
+    pub(crate) path: PathBuf,
+    pub(crate) rows: u64,
+    pub(crate) elapsed_us: u64,
+    pub(crate) missing_samples: u64,
+    pub(crate) interpolated_duration_us: u64,
+}
+
+impl Recorder {
+    pub(crate) fn start(
+        path: PathBuf,
+        format: RecordingFormat,
+        metadata: RecordingMetadata,
+        origin: Option<MeasurementSample>,
+    ) -> Result<Self, String> {
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        if !parent.exists() {
+            return Err(format!("output directory does not exist: {}", parent.display()));
+        }
+
+        let partial_path = partial_path(&path);
+        let (command_tx, command_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
+        let (event_tx, event_rx) = mpsc::channel();
+        let final_path = path.clone();
+        let handle = thread::Builder::new()
+            .name("km003c-recorder".to_string())
+            .spawn(move || {
+                let result = run_writer(&partial_path, format, metadata, command_rx).and_then(|summary| {
+                    replace_file(&partial_path, &final_path)?;
+                    Ok(RecordingSummary {
+                        path: final_path,
+                        ..summary
+                    })
+                });
+                let event = match result {
+                    Ok(summary) => RecordingEvent::Finished(summary),
+                    Err(error) => RecordingEvent::Failed(format!(
+                        "{error}; incomplete recording remains at {}",
+                        partial_path.display()
+                    )),
+                };
+                let _ = event_tx.send(event);
+            })
+            .map_err(|error| format!("failed to start recording thread: {error}"))?;
+
+        Ok(Self {
+            command_tx,
+            event_rx,
+            handle: Some(handle),
+            origin: origin.into(),
+            next_sample_index: 0,
+            finishing: false,
+            interrupted: None,
+            path,
+            rows: 0,
+            elapsed_us: 0,
+            missing_samples: 0,
+            interpolated_duration_us: 0,
+        })
+    }
+
+    pub(crate) fn push(&mut self, samples: &[MeasurementSample]) -> Result<(), String> {
+        if self.finishing || samples.is_empty() {
+            return Ok(());
+        }
+
+        let first_sample_index = self.next_sample_index;
+        let rows = samples
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(offset, sample)| RecordingRow::from_sample(sample, self.origin, first_sample_index + offset as u64))
+            .collect::<Vec<_>>();
+
+        match self.command_tx.try_send(WriterCommand::Rows(rows)) {
+            Ok(()) => {
+                self.next_sample_index += samples.len() as u64;
+                if let Some(last) = samples.last() {
+                    let last = RecordingRow::from_sample(*last, self.origin, self.next_sample_index - 1);
+                    self.rows = self.next_sample_index;
+                    self.elapsed_us = last.elapsed_us;
+                    self.missing_samples = last.cumulative_missing_samples;
+                    self.interpolated_duration_us = last.cumulative_interpolated_duration_us;
+                }
+                Ok(())
+            }
+            Err(TrySendError::Full(_)) => {
+                let error = "recording writer could not keep up; capture stopped rather than dropping rows".to_string();
+                self.interrupted = Some(error.clone());
+                Err(error)
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                let error = "recording writer stopped unexpectedly".to_string();
+                self.interrupted = Some(error.clone());
+                Err(error)
+            }
+        }
+    }
+
+    pub(crate) fn request_finish(&mut self) -> Result<(), String> {
+        if !self.finishing {
+            self.command_tx
+                .send(WriterCommand::Finish)
+                .map_err(|_| "recording writer stopped unexpectedly".to_string())?;
+            self.finishing = true;
+        }
+        Ok(())
+    }
+
+    pub(crate) const fn is_finishing(&self) -> bool {
+        self.finishing
+    }
+
+    pub(crate) fn poll_event(&mut self) -> Option<RecordingEvent> {
+        match self.event_rx.try_recv() {
+            Ok(mut event) => {
+                if let Some(handle) = self.handle.take() {
+                    let _ = handle.join();
+                }
+                if let (RecordingEvent::Finished(summary), Some(reason)) = (&event, self.interrupted.take()) {
+                    event = RecordingEvent::Interrupted(summary.clone(), reason);
+                }
+                Some(event)
+            }
+            Err(TryRecvError::Empty) => None,
+            Err(TryRecvError::Disconnected) => Some(RecordingEvent::Failed(
+                "recording writer exited without reporting a result".to_string(),
+            )),
+        }
+    }
+}
+
+impl Drop for Recorder {
+    fn drop(&mut self) {
+        if !self.finishing {
+            let _ = self.command_tx.send(WriterCommand::Finish);
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn run_writer(
+    partial_path: &Path,
+    format: RecordingFormat,
+    metadata: RecordingMetadata,
+    command_rx: Receiver<WriterCommand>,
+) -> Result<RecordingSummary, Box<dyn Error + Send + Sync>> {
+    let file = File::create(partial_path)?;
+    match format {
+        RecordingFormat::Parquet => write_parquet(file, metadata, command_rx, partial_path),
+        RecordingFormat::Csv => write_csv(file, command_rx, partial_path),
+    }
+}
+
+fn write_parquet(
+    file: File,
+    metadata: RecordingMetadata,
+    command_rx: Receiver<WriterCommand>,
+    partial_path: &Path,
+) -> Result<RecordingSummary, Box<dyn Error + Send + Sync>> {
+    let metadata = KeyValueMetadata::from_static(vec![
+        (
+            "km003c.schema_version".to_string(),
+            RECORDING_SCHEMA_VERSION.to_string(),
+        ),
+        ("km003c.source".to_string(), "live".to_string()),
+        ("km003c.accumulator_source".to_string(), "host_trapezoidal".to_string()),
+        ("km003c.model".to_string(), metadata.model),
+        ("km003c.firmware".to_string(), metadata.firmware),
+        ("km003c.serial".to_string(), metadata.serial),
+    ]);
+    let empty = rows_to_dataframe(&[])?;
+    let mut writer = ParquetWriter::new(BufWriter::new(file))
+        .with_key_value_metadata(Some(metadata))
+        .with_row_group_size(Some(ROW_GROUP_SIZE))
+        .batched(empty.schema())?;
+    let summary = consume_rows(
+        command_rx,
+        |rows| {
+            let dataframe = rows_to_dataframe(rows)?;
+            writer.write_batch(&dataframe)?;
+            Ok(())
+        },
+        partial_path,
+    )?;
+    writer.finish()?;
+    Ok(summary)
+}
+
+fn write_csv(
+    file: File,
+    command_rx: Receiver<WriterCommand>,
+    partial_path: &Path,
+) -> Result<RecordingSummary, Box<dyn Error + Send + Sync>> {
+    let empty = rows_to_dataframe(&[])?;
+    let mut writer = CsvWriter::new(BufWriter::new(file)).batched(empty.schema())?;
+    let summary = consume_rows(
+        command_rx,
+        |rows| {
+            let dataframe = rows_to_dataframe(rows)?;
+            writer.write_batch(&dataframe)?;
+            Ok(())
+        },
+        partial_path,
+    )?;
+    writer.finish()?;
+    Ok(summary)
+}
+
+fn consume_rows<F>(
+    command_rx: Receiver<WriterCommand>,
+    mut write: F,
+    partial_path: &Path,
+) -> Result<RecordingSummary, Box<dyn Error + Send + Sync>>
+where
+    F: FnMut(&[RecordingRow]) -> Result<(), Box<dyn Error + Send + Sync>>,
+{
+    let mut buffered = Vec::with_capacity(ROW_GROUP_SIZE);
+    let mut summary = RecordingSummary {
+        path: partial_path.to_path_buf(),
+        rows: 0,
+        elapsed_us: 0,
+        missing_samples: 0,
+        interpolated_duration_us: 0,
+    };
+
+    loop {
+        match command_rx.recv()? {
+            WriterCommand::Rows(mut rows) => {
+                if let Some(last) = rows.last() {
+                    summary.rows = last.sample_index + 1;
+                    summary.elapsed_us = last.elapsed_us;
+                    summary.missing_samples = last.cumulative_missing_samples;
+                    summary.interpolated_duration_us = last.cumulative_interpolated_duration_us;
+                }
+                buffered.append(&mut rows);
+                if buffered.len() >= ROW_GROUP_SIZE {
+                    write(&buffered)?;
+                    buffered.clear();
+                }
+            }
+            WriterCommand::Finish => {
+                if !buffered.is_empty() {
+                    write(&buffered)?;
+                }
+                return Ok(summary);
+            }
+        }
+    }
+}
+
+fn rows_to_dataframe(rows: &[RecordingRow]) -> Result<DataFrame, polars::error::PolarsError> {
+    df!(
+        "elapsed_us" => rows.iter().map(|row| row.elapsed_us).collect::<Vec<_>>(),
+        "sample_index" => rows.iter().map(|row| row.sample_index).collect::<Vec<_>>(),
+        "sequence" => rows.iter().map(|row| row.sequence).collect::<Vec<_>>(),
+        "marker" => rows.iter().map(|row| row.marker).collect::<Vec<_>>(),
+        "sample_rate_hz" => rows.iter().map(|row| row.sample_rate_hz).collect::<Vec<_>>(),
+        "missing_samples" => rows.iter().map(|row| row.missing_samples).collect::<Vec<_>>(),
+        "gap_duration_us" => rows.iter().map(|row| row.gap_duration_us).collect::<Vec<_>>(),
+        "interpolated" => rows.iter().map(|row| row.interpolated).collect::<Vec<_>>(),
+        "cumulative_missing_samples" => rows.iter().map(|row| row.cumulative_missing_samples).collect::<Vec<_>>(),
+        "cumulative_interpolated_duration_us" => rows.iter().map(|row| row.cumulative_interpolated_duration_us).collect::<Vec<_>>(),
+        "vbus_uv" => rows.iter().map(|row| row.vbus_uv).collect::<Vec<_>>(),
+        "ibus_ua" => rows.iter().map(|row| row.ibus_ua).collect::<Vec<_>>(),
+        "power_uw" => rows.iter().map(|row| row.power_uw).collect::<Vec<_>>(),
+        "charge_uah" => rows.iter().map(|row| row.charge_uah).collect::<Vec<_>>(),
+        "energy_uwh" => rows.iter().map(|row| row.energy_uwh).collect::<Vec<_>>(),
+        "cc1_uv" => rows.iter().map(|row| row.cc1_uv).collect::<Vec<_>>(),
+        "cc2_uv" => rows.iter().map(|row| row.cc2_uv).collect::<Vec<_>>(),
+        "dp_uv" => rows.iter().map(|row| row.dp_uv).collect::<Vec<_>>(),
+        "dm_uv" => rows.iter().map(|row| row.dm_uv).collect::<Vec<_>>(),
+    )
+}
+
+fn partial_path(path: &Path) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(".partial");
+    PathBuf::from(name)
+}
+
+fn replace_file(partial: &Path, final_path: &Path) -> std::io::Result<()> {
+    if final_path.exists() {
+        std::fs::remove_file(final_path)?;
+    }
+    std::fs::rename(partial, final_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use polars::prelude::{CsvReader, ParquetReader, SerReader};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_TEST_FILE: AtomicU64 = AtomicU64::new(0);
+
+    fn sample(elapsed_us: u64, missing: u64, interpolated_us: u64) -> MeasurementSample {
+        MeasurementSample {
+            elapsed_us,
+            sample_index: 100,
+            sequence: 42,
+            marker: 7,
+            sample_rate_hz: 50,
+            missing_samples: missing as u16,
+            gap_duration_us: interpolated_us,
+            interpolated: missing > 0,
+            cumulative_missing_samples: missing,
+            cumulative_interpolated_duration_us: interpolated_us,
+            vbus_uv: 5_000_000,
+            ibus_ua: -1_000_000,
+            power_uw: -5_000_000,
+            charge_uah: -100.0,
+            energy_uwh: -500.0,
+            cc1_uv: 1_000_000,
+            cc2_uv: 0,
+            dp_uv: 600_000,
+            dm_uv: 500_000,
+        }
+    }
+
+    #[test]
+    fn recording_rows_are_relative_to_the_start() {
+        let origin = RecordingOrigin::from(Some(sample(1_000_000, 2, 40_000)));
+        let row = RecordingRow::from_sample(sample(2_000_000, 3, 60_000), origin, 0);
+
+        assert_eq!(row.elapsed_us, 1_000_000);
+        assert_eq!(row.sample_index, 0);
+        assert_eq!(row.cumulative_missing_samples, 1);
+        assert_eq!(row.cumulative_interpolated_duration_us, 20_000);
+        assert_eq!(row.charge_uah, 0.0);
+    }
+
+    #[test]
+    fn completeness_reports_interpolated_time_fraction() {
+        let summary = RecordingSummary {
+            path: PathBuf::new(),
+            rows: 10,
+            elapsed_us: 1_000_000,
+            missing_samples: 2,
+            interpolated_duration_us: 10_000,
+        };
+        assert_eq!(summary.completeness_percent(), 99.0);
+    }
+
+    #[test]
+    fn dataframe_uses_the_stable_recording_schema() {
+        let row = RecordingRow::from_sample(sample(1_000, 0, 0), RecordingOrigin::from(None), 0);
+        let dataframe = rows_to_dataframe(&[row]).unwrap();
+
+        assert_eq!(dataframe.height(), 1);
+        assert_eq!(dataframe.width(), 19);
+        assert_eq!(
+            dataframe.column("vbus_uv").unwrap().i64().unwrap().get(0),
+            Some(5_000_000)
+        );
+    }
+
+    #[test]
+    fn parquet_writer_produces_a_readable_recording() {
+        let path = test_path("parquet");
+        let summary = write_test_recording(&path, RecordingFormat::Parquet);
+        let dataframe = ParquetReader::new(File::open(&path).unwrap()).finish().unwrap();
+
+        assert_eq!(summary.rows, 2);
+        assert_eq!(dataframe.shape(), (2, 19));
+        assert_eq!(
+            dataframe.column("elapsed_us").unwrap().u64().unwrap().get(1),
+            Some(20_000)
+        );
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn csv_writer_produces_a_readable_recording() {
+        let path = test_path("csv");
+        let summary = write_test_recording(&path, RecordingFormat::Csv);
+        let dataframe = CsvReader::new(File::open(&path).unwrap()).finish().unwrap();
+
+        assert_eq!(summary.rows, 2);
+        assert_eq!(dataframe.shape(), (2, 19));
+        assert_eq!(
+            dataframe.column("vbus_uv").unwrap().i64().unwrap().get(0),
+            Some(5_000_000)
+        );
+        std::fs::remove_file(path).unwrap();
+    }
+
+    fn write_test_recording(path: &Path, format: RecordingFormat) -> RecordingSummary {
+        let (command_tx, command_rx) = mpsc::sync_channel(2);
+        let rows = vec![
+            RecordingRow::from_sample(sample(0, 0, 0), RecordingOrigin::from(None), 0),
+            RecordingRow::from_sample(sample(20_000, 1, 20_000), RecordingOrigin::from(None), 1),
+        ];
+        command_tx.send(WriterCommand::Rows(rows)).unwrap();
+        command_tx.send(WriterCommand::Finish).unwrap();
+
+        run_writer(
+            path,
+            format,
+            RecordingMetadata {
+                model: "KM003C".to_string(),
+                firmware: "1.9.9".to_string(),
+                serial: "test".to_string(),
+            },
+            command_rx,
+        )
+        .unwrap()
+    }
+
+    fn test_path(extension: &str) -> PathBuf {
+        let unique = NEXT_TEST_FILE.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "km003c-recording-test-{}-{unique}.{extension}",
+            std::process::id()
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

- add opt-in polling of the KM003C firmware PD trace alongside ADC and wire-level PD data
- merge wire messages and firmware events into one timestamp-ordered PD timeline
- add independent protocol/firmware filters, source labels, colors, bounded buffering, and lossless unknown-state display
- expose timestamps from the existing semantic PD formatter so both sources can be ordered without parsing display strings

Firmware trace collection remains disabled by default because reading it drains the device queues. The UI identifies the trace as reverse engineered from KM003C firmware V1.9.9 and explains its one-second timestamp resolution.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all`
- real KM003C V1.9.9 at 50 SPS, first with the measured port open and then while charging a Pixel 8 Pro over PPS
- observed interleaved PPS Request/GoodCRC/Accept/PS_RDY wire messages and firmware `ReceivedMessage` markers
- observed matching wire disconnect plus firmware `AttachedResistance` and `Disabled` transitions when unplugging the phone
- controlled 20-second combined-polling interval added no dropped ADC samples or USB/parser errors