### PR TITLE
Add offline recording browser to egui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,6 +2505,7 @@ version = "0.2.0"
 dependencies = [
  "eframe",
  "egui_plot",
+ "hex",
  "km003c-lib",
  "polars",
  "rfd",

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ GUI application featuring:
 - AdcQueue streaming with configurable sample rates
 - Adjustable time window (2s to 5min or all data)
 - Live recording and plot-buffer export to Parquet or CSV
+- Device-stored offline recording catalog, download, plotting, and Parquet/CSV export
 - Host-integrated charge and energy with explicit missing-sample quality data
 - Device info panel with auth status
 - Connect/disconnect control
@@ -159,6 +160,15 @@ samples are excluded from plots and integration and counted by
 `discarded_sequence_samples` and `cumulative_discarded_sequence_samples`. The
 GUI reports completeness as the fraction of elapsed time covered by received
 intervals rather than estimated gap intervals.
+
+The **Offline Recordings** section loads the catalog stored by the KM003C,
+downloads a selected entry, and switches the same three plots between live and
+offline data. Offline exports use the same 23-column Parquet/CSV schema as live
+captures. Fields that the device does not store in offline samples—sequence,
+marker, sample rate, gap quality, CC1/CC2, and D+/D-—are null rather than
+fabricated as zero. Signed charge and energy preserve the device accumulators;
+positive throughput is derived from the absolute changes between successive
+device accumulator values.
 
 ## Library Usage
 

--- a/km003c-egui/Cargo.toml
+++ b/km003c-egui/Cargo.toml
@@ -22,3 +22,6 @@ rfd = "0.17.2"
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[dev-dependencies]
+hex = "0.4.3"

--- a/km003c-egui/src/main.rs
+++ b/km003c-egui/src/main.rs
@@ -1,4 +1,6 @@
 mod measurement;
+mod offline_export;
+mod offline_view;
 mod pd_connection;
 mod pd_decoder;
 mod pd_trace_view;
@@ -6,13 +8,18 @@ mod recording;
 
 use eframe::egui;
 use egui_plot::{Line, Plot, PlotPoints};
+use km003c_lib::uom::si::electric_charge::milliampere_hour;
 use km003c_lib::uom::si::electric_potential::volt;
+use km003c_lib::uom::si::energy::milliwatt_hour;
+use km003c_lib::uom::si::time::{millisecond, second};
 use km003c_lib::{
-    AdcQueueSample, DeviceConfig, DeviceState, GraphSampleRate, KM003C, PdTrace,
+    AdcQueueSample, DeviceConfig, DeviceState, GraphSampleRate, KM003C, LogMetadata, OfflineLog, PdTrace,
     packet::{Attribute, AttributeSet},
     pd::{PdEvent, PdEventData, PdStatus},
 };
 use measurement::{MeasurementAccumulator, MeasurementSample, PlotMetric};
+use offline_export::{OfflineExportEvent, OfflineExportTask};
+use offline_view::OfflineRecordingView;
 use pd_connection::PdConnectionTracker;
 use pd_decoder::{DecodedPdEntry, PdCategory, PdDecoder};
 use pd_trace_view::{PdTraceCategory, PdTraceEntry, decode_trace};
@@ -38,6 +45,12 @@ enum UsbMessage {
     PdStatusUpdate(PdStatus),
     /// Firmware Type-C and protocol-engine trace
     PdTrace(PdTrace),
+    /// Device offline-recording catalog
+    OfflineCatalog(Vec<LogMetadata>),
+    /// Complete selected offline recording
+    OfflineLogDownloaded(OfflineLog),
+    /// Offline catalog or download operation failed
+    OfflineOperationFailed(String),
     /// Streaming started at given rate
     StreamingStarted(GraphSampleRate),
     /// Streaming stopped
@@ -57,8 +70,18 @@ enum UsbCommand {
     SetSampleRate(GraphSampleRate),
     /// Enable or disable firmware PD trace collection
     SetPdTraceEnabled(bool),
+    /// Fetch the catalog of recordings stored by the device
+    RequestOfflineCatalog,
+    /// Download one catalog entry from device memory
+    DownloadOfflineLog(LogMetadata),
     /// Stop streaming and disconnect
     Disconnect,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PlotSource {
+    Live,
+    Offline,
 }
 
 enum PdTimelineEntry<'a> {
@@ -216,6 +239,22 @@ struct PowerMonitorApp {
     recording_status: String,
     /// Summary of the last completed recording
     last_recording: Option<RecordingSummary>,
+    /// Device-side offline recording catalog
+    offline_catalog: Vec<LogMetadata>,
+    /// Selected catalog row
+    offline_selected: Option<usize>,
+    /// Downloaded offline recording and plot data
+    offline_view: Option<Arc<OfflineRecordingView>>,
+    /// Device identity retained with the downloaded recording for export
+    offline_device_metadata: Option<RecordingMetadata>,
+    /// Whether a device catalog or download operation is running
+    offline_busy: bool,
+    /// Offline browser and export status
+    offline_status: String,
+    /// Background export of a downloaded offline recording
+    offline_export: Option<OfflineExportTask>,
+    /// Data source currently rendered by the three plots
+    plot_source: PlotSource,
     /// PD protocol decoder
     pd_decoder: PdDecoder,
     /// Decoded PD log entries
@@ -267,6 +306,14 @@ impl PowerMonitorApp {
             recorder: None,
             recording_status: "Not recording".to_string(),
             last_recording: None,
+            offline_catalog: Vec::new(),
+            offline_selected: None,
+            offline_view: None,
+            offline_device_metadata: None,
+            offline_busy: false,
+            offline_status: "Catalog not loaded".to_string(),
+            offline_export: None,
+            plot_source: PlotSource::Live,
             pd_decoder: PdDecoder::new(),
             pd_log: VecDeque::new(),
             max_pd_entries: 1000,
@@ -288,6 +335,9 @@ impl PowerMonitorApp {
                 UsbMessage::Connected(state) => {
                     self.status = format!("Connected: {}", state.model());
                     self.device_state = Some(state);
+                    self.offline_catalog.clear();
+                    self.offline_selected = None;
+                    self.offline_status = "Catalog not loaded".to_string();
                     self.pd_connection = PdConnectionTracker::default();
                     if self.pd_trace_enabled {
                         let _ = self.cmd_sender.send(UsbCommand::SetPdTraceEnabled(true));
@@ -371,6 +421,39 @@ impl PowerMonitorApp {
                         }
                     }
                 }
+                UsbMessage::OfflineCatalog(catalog) => {
+                    self.offline_busy = false;
+                    self.offline_status = if catalog.is_empty() {
+                        "No offline recordings stored on the device".to_string()
+                    } else {
+                        format!("Loaded {} offline recording(s)", catalog.len())
+                    };
+                    self.offline_selected = (!catalog.is_empty()).then_some(0);
+                    self.offline_catalog = catalog;
+                }
+                UsbMessage::OfflineLogDownloaded(log) => {
+                    let samples = log.samples.len();
+                    let filename = log.metadata.filename_lossy().into_owned();
+                    self.offline_view = Some(Arc::new(OfflineRecordingView::new(log)));
+                    self.offline_device_metadata = self.device_state.as_ref().map(|state| RecordingMetadata {
+                        model: state.info.model.clone(),
+                        firmware: state.info.fw_version.clone(),
+                        serial: state.info.serial_id.clone(),
+                    });
+                    self.offline_busy = false;
+                    self.offline_status = format!("Downloaded {samples} samples from {filename}");
+                    self.plot_source = PlotSource::Offline;
+                    self.time_window = TimeWindow::All;
+                    for metric in &mut self.plot_metrics {
+                        if !metric.supports_offline() {
+                            *metric = PlotMetric::Voltage;
+                        }
+                    }
+                }
+                UsbMessage::OfflineOperationFailed(error) => {
+                    self.offline_busy = false;
+                    self.offline_status = error;
+                }
                 UsbMessage::StreamingStopped => {
                     self.streaming = false;
                     self.status = "Stopped".to_string();
@@ -384,6 +467,7 @@ impl PowerMonitorApp {
                     self.device_state = None;
                     self.pd_status = None;
                     self.pd_connection = PdConnectionTracker::default();
+                    self.offline_busy = false;
                     self.stop_recording();
                 }
             }
@@ -391,6 +475,7 @@ impl PowerMonitorApp {
 
         self.pd_connection.update(std::time::Instant::now());
         self.poll_recording();
+        self.poll_offline_export();
     }
 
     fn clear_data(&mut self) {
@@ -525,6 +610,91 @@ impl PowerMonitorApp {
             None => {}
         }
     }
+
+    fn request_offline_catalog(&mut self) {
+        if self.device_state.is_none() {
+            self.offline_status = "Connect the KM003C before loading its offline catalog".to_string();
+            return;
+        }
+        if self.offline_busy || self.recorder.is_some() || self.offline_export.is_some() {
+            return;
+        }
+        self.offline_busy = true;
+        self.offline_status = "Loading offline recording catalog...".to_string();
+        if self.cmd_sender.send(UsbCommand::RequestOfflineCatalog).is_err() {
+            self.offline_busy = false;
+            self.offline_status = "USB task is not available".to_string();
+        }
+    }
+
+    fn download_selected_offline_log(&mut self) {
+        if self.device_state.is_none() {
+            self.offline_status = "Connect the KM003C before downloading an offline recording".to_string();
+            return;
+        }
+        if self.offline_busy || self.recorder.is_some() || self.offline_export.is_some() {
+            return;
+        }
+        let Some(metadata) = self
+            .offline_selected
+            .and_then(|index| self.offline_catalog.get(index))
+            .cloned()
+        else {
+            self.offline_status = "Select an offline recording first".to_string();
+            return;
+        };
+        self.offline_busy = true;
+        self.offline_status = format!(
+            "Downloading {} samples from {}...",
+            metadata.sample_count,
+            metadata.filename_lossy()
+        );
+        if self.cmd_sender.send(UsbCommand::DownloadOfflineLog(metadata)).is_err() {
+            self.offline_busy = false;
+            self.offline_status = "USB task is not available".to_string();
+        }
+    }
+
+    fn export_offline_log(&mut self) {
+        if self.offline_export.is_some() {
+            return;
+        }
+        let (Some(view), Some(device)) = (&self.offline_view, &self.offline_device_metadata) else {
+            self.offline_status = "Download an offline recording before exporting it".to_string();
+            return;
+        };
+        let device_filename = view.log.metadata.filename_lossy();
+        let prefix = std::path::Path::new(device_filename.as_ref())
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .unwrap_or("offline-log");
+        let Some(path) = self.select_recording_path(prefix, "Export KM003C offline recording") else {
+            return;
+        };
+        match OfflineExportTask::start(path.clone(), self.recording_format, device.clone(), Arc::clone(view)) {
+            Ok(task) => {
+                self.offline_status = format!("Exporting to {}", path.display());
+                self.offline_export = Some(task);
+            }
+            Err(error) => self.offline_status = error,
+        }
+    }
+
+    fn poll_offline_export(&mut self) {
+        let event = self.offline_export.as_mut().and_then(OfflineExportTask::poll_event);
+        match event {
+            Some(OfflineExportEvent::Finished { path, rows }) => {
+                self.offline_status = format!("Exported {rows} samples to {}", path.display());
+                self.offline_export = None;
+            }
+            Some(OfflineExportEvent::Failed(error)) => {
+                self.offline_status = error;
+                self.offline_export = None;
+            }
+            None => {}
+        }
+    }
 }
 
 impl eframe::App for PowerMonitorApp {
@@ -532,7 +702,7 @@ impl eframe::App for PowerMonitorApp {
         self.process_messages();
 
         // Request repaints - fast when streaming, slower when idle
-        if self.streaming {
+        if self.streaming && self.plot_source == PlotSource::Live {
             ui.ctx().request_repaint_after(Duration::from_millis(16)); // ~60fps when streaming
         } else {
             ui.ctx().request_repaint_after(Duration::from_millis(100)); // 10fps when idle
@@ -713,7 +883,7 @@ impl eframe::App for PowerMonitorApp {
 
             ui.add_space(20.0);
             ui.separator();
-            ui.heading("Statistics");
+            ui.heading("Live Statistics");
             ui.separator();
 
             egui::Grid::new("stats_grid")
@@ -801,7 +971,9 @@ impl eframe::App for PowerMonitorApp {
                         .selected_text(metric.label())
                         .show_ui(ui, |ui| {
                             for option in PlotMetric::ALL {
-                                ui.selectable_value(metric, option, option.label());
+                                if self.plot_source == PlotSource::Live || option.supports_offline() {
+                                    ui.selectable_value(metric, option, option.label());
+                                }
                             }
                         });
                 });
@@ -811,7 +983,7 @@ impl eframe::App for PowerMonitorApp {
 
             ui.horizontal(|ui| {
                 if ui
-                    .add_enabled(self.recorder.is_none(), egui::Button::new("Clear Data"))
+                    .add_enabled(self.recorder.is_none(), egui::Button::new("Clear Live Data"))
                     .clicked()
                 {
                     self.clear_data();
@@ -880,6 +1052,134 @@ impl eframe::App for PowerMonitorApp {
                 ui.label(format!("Completeness: {:.6}%", summary.completeness_percent()));
             }
             ui.small(&self.recording_status);
+
+            ui.add_space(20.0);
+            ui.separator();
+            ui.heading("Offline Recordings");
+            ui.separator();
+
+            ui.horizontal(|ui| {
+                if ui
+                    .add_enabled(
+                        self.device_state.is_some()
+                            && !self.offline_busy
+                            && self.recorder.is_none()
+                            && self.offline_export.is_none(),
+                        egui::Button::new("Refresh Catalog"),
+                    )
+                    .clicked()
+                {
+                    self.request_offline_catalog();
+                }
+                if self.offline_busy {
+                    ui.spinner();
+                }
+            });
+
+            if !self.offline_catalog.is_empty() {
+                let selected_text = self
+                    .offline_selected
+                    .and_then(|index| self.offline_catalog.get(index))
+                    .map_or_else(|| "Select a recording".to_string(), |metadata| metadata.filename_lossy().into_owned());
+                egui::ComboBox::from_id_salt("offline_recording")
+                    .selected_text(selected_text)
+                    .show_ui(ui, |ui| {
+                        for (index, metadata) in self.offline_catalog.iter().enumerate() {
+                            ui.selectable_value(
+                                &mut self.offline_selected,
+                                Some(index),
+                                format!(
+                                    "#{} {} ({} samples)",
+                                    index,
+                                    metadata.filename_lossy(),
+                                    metadata.sample_count
+                                ),
+                            );
+                        }
+                    });
+
+                if let Some(metadata) = self
+                    .offline_selected
+                    .and_then(|index| self.offline_catalog.get(index))
+                {
+                    egui::Grid::new("offline_metadata_grid")
+                        .num_columns(2)
+                        .spacing([10.0, 4.0])
+                        .show(ui, |ui| {
+                            ui.label("Samples:");
+                            ui.label(metadata.sample_count.to_string());
+                            ui.end_row();
+                            ui.label("Interval:");
+                            ui.label(format!("{} ms", metadata.interval.get::<millisecond>()));
+                            ui.end_row();
+                            ui.label("Duration:");
+                            ui.label(format!("{:.1} s", metadata.recorded_duration.get::<second>()));
+                            ui.end_row();
+                            ui.label("Final charge:");
+                            ui.label(format!("{:.3} mAh", metadata.final_charge.get::<milliampere_hour>()));
+                            ui.end_row();
+                            ui.label("Final energy:");
+                            ui.label(format!("{:.3} mWh", metadata.final_energy.get::<milliwatt_hour>()));
+                            ui.end_row();
+                        });
+                }
+
+                if ui
+                    .add_enabled(
+                        self.device_state.is_some()
+                            && self.offline_selected.is_some()
+                            && !self.offline_busy
+                            && self.recorder.is_none()
+                            && self.offline_export.is_none(),
+                        egui::Button::new("Download and View"),
+                    )
+                    .clicked()
+                {
+                    self.download_selected_offline_log();
+                }
+            }
+
+            if let Some(view) = &self.offline_view {
+                ui.label(format!(
+                    "Loaded: {} ({} samples)",
+                    view.log.metadata.filename_lossy(),
+                    view.samples.len()
+                ));
+                let previous_source = self.plot_source;
+                ui.horizontal(|ui| {
+                    ui.selectable_value(&mut self.plot_source, PlotSource::Live, "View Live");
+                    ui.selectable_value(&mut self.plot_source, PlotSource::Offline, "View Offline");
+                });
+                if previous_source != self.plot_source && self.plot_source == PlotSource::Offline {
+                    self.time_window = TimeWindow::All;
+                    for metric in &mut self.plot_metrics {
+                        if !metric.supports_offline() {
+                            *metric = PlotMetric::Voltage;
+                        }
+                    }
+                }
+                ui.add_enabled_ui(self.offline_export.is_none() && self.recorder.is_none(), |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label("Export format:");
+                        egui::ComboBox::from_id_salt("offline_recording_format")
+                            .selected_text(self.recording_format.label())
+                            .show_ui(ui, |ui| {
+                                for format in RecordingFormat::ALL {
+                                    ui.selectable_value(&mut self.recording_format, format, format.label());
+                                }
+                            });
+                    });
+                });
+                if let Some(export) = &self.offline_export {
+                    ui.horizontal(|ui| {
+                        ui.spinner();
+                        ui.label(format!("Exporting {}", export.path.display()));
+                    });
+                } else if ui.button("Export Downloaded").clicked() {
+                    self.export_offline_log();
+                }
+            }
+            ui.small(&self.offline_status);
 
             ui.add_space(5.0);
 
@@ -980,10 +1280,27 @@ impl eframe::App for PowerMonitorApp {
 
         // Main panel with plots
         egui::CentralPanel::default().show(ui, |ui| {
+            match self.plot_source {
+                PlotSource::Live => ui.small("Plot source: live AdcQueue"),
+                PlotSource::Offline => {
+                    let filename = self
+                        .offline_view
+                        .as_ref()
+                        .map_or_else(|| "not loaded".into(), |view| view.log.metadata.filename_lossy());
+                    ui.small(format!("Plot source: offline recording {filename}"))
+                }
+            };
             let available_height = ui.available_height();
             let plot_height = (available_height - 30.0) / 3.0;
 
-            let current_time = self.data_points.back().map_or(0.0, |sample| sample.elapsed_seconds());
+            let current_time = match self.plot_source {
+                PlotSource::Live => self.data_points.back().map_or(0.0, |sample| sample.elapsed_seconds()),
+                PlotSource::Offline => self
+                    .offline_view
+                    .as_ref()
+                    .and_then(|view| view.samples.last())
+                    .map_or(0.0, |sample| sample.elapsed_seconds()),
+            };
             let min_time = self
                 .time_window
                 .seconds()
@@ -999,12 +1316,25 @@ impl eframe::App for PowerMonitorApp {
                     .allow_drag(true)
                     .allow_scroll(true)
                     .show(ui, |plot_ui| {
-                        let points: PlotPoints = self
-                            .data_points
-                            .iter()
-                            .filter(|sample| min_time.is_none_or(|min| sample.elapsed_seconds() >= min))
-                            .map(|sample| [sample.elapsed_seconds(), metric.value(sample)])
-                            .collect();
+                        let points: PlotPoints = match self.plot_source {
+                            PlotSource::Live => self
+                                .data_points
+                                .iter()
+                                .filter(|sample| min_time.is_none_or(|min| sample.elapsed_seconds() >= min))
+                                .map(|sample| [sample.elapsed_seconds(), metric.value(sample)])
+                                .collect(),
+                            PlotSource::Offline => self
+                                .offline_view
+                                .iter()
+                                .flat_map(|view| &view.samples)
+                                .filter(|sample| min_time.is_none_or(|min| sample.elapsed_seconds() >= min))
+                                .filter_map(|sample| {
+                                    sample
+                                        .metric_value(metric)
+                                        .map(|value| [sample.elapsed_seconds(), value])
+                                })
+                                .collect(),
+                        };
                         plot_ui.line(Line::new(metric.label(), points).color(metric.color()).width(1.5_f32));
                     });
             }
@@ -1031,7 +1361,11 @@ async fn usb_streaming_task(tx: mpsc::UnboundedSender<UsbMessage>, mut cmd_rx: m
                 info!("Connect command received, rate={:?}, reset={}", initial_rate, usb_reset);
                 run_streaming_session(&tx, &mut cmd_rx, initial_rate, usb_reset).await;
             }
-            UsbCommand::SetSampleRate(_) | UsbCommand::SetPdTraceEnabled(_) | UsbCommand::Disconnect => {
+            UsbCommand::SetSampleRate(_)
+            | UsbCommand::SetPdTraceEnabled(_)
+            | UsbCommand::RequestOfflineCatalog
+            | UsbCommand::DownloadOfflineLog(_)
+            | UsbCommand::Disconnect => {
                 // Ignore these when not connected
                 debug!("Ignoring command while disconnected: {:?}", cmd);
             }
@@ -1116,6 +1450,62 @@ async fn run_streaming_session(
                     "Firmware PD trace collection {}",
                     if enabled { "enabled" } else { "disabled" }
                 );
+            }
+            Ok(UsbCommand::RequestOfflineCatalog) => {
+                info!("Loading offline recording catalog");
+                if let Err(error) = device.stop_graph_mode().await {
+                    let _ = tx.send(UsbMessage::OfflineOperationFailed(format!(
+                        "Could not pause streaming for offline catalog access: {error}"
+                    )));
+                    continue;
+                }
+                let _ = tx.send(UsbMessage::StreamingStopped);
+                match device.request_log_metadata().await {
+                    Ok(catalog) => {
+                        let _ = tx.send(UsbMessage::OfflineCatalog(catalog));
+                    }
+                    Err(error) => {
+                        let _ = tx.send(UsbMessage::OfflineOperationFailed(format!(
+                            "Failed to load offline catalog: {error}"
+                        )));
+                    }
+                }
+                if let Err(error) = start_streaming(&mut device, current_rate, tx).await {
+                    let _ = tx.send(UsbMessage::Error(format!(
+                        "Failed to resume streaming after loading offline catalog: {error}"
+                    )));
+                    break;
+                }
+            }
+            Ok(UsbCommand::DownloadOfflineLog(metadata)) => {
+                info!(
+                    filename = %metadata.filename_lossy(),
+                    samples = metadata.sample_count,
+                    "Downloading offline recording"
+                );
+                if let Err(error) = device.stop_graph_mode().await {
+                    let _ = tx.send(UsbMessage::OfflineOperationFailed(format!(
+                        "Could not pause streaming for offline download: {error}"
+                    )));
+                    continue;
+                }
+                let _ = tx.send(UsbMessage::StreamingStopped);
+                match device.download_offline_log(metadata).await {
+                    Ok(log) => {
+                        let _ = tx.send(UsbMessage::OfflineLogDownloaded(log));
+                    }
+                    Err(error) => {
+                        let _ = tx.send(UsbMessage::OfflineOperationFailed(format!(
+                            "Failed to download offline recording: {error}"
+                        )));
+                    }
+                }
+                if let Err(error) = start_streaming(&mut device, current_rate, tx).await {
+                    let _ = tx.send(UsbMessage::Error(format!(
+                        "Failed to resume streaming after offline download: {error}"
+                    )));
+                    break;
+                }
             }
             Ok(UsbCommand::Disconnect) => {
                 info!("Disconnect command received");
@@ -1241,6 +1631,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::offline_view::captured_test_view;
+    use polars::prelude::{CsvReader, ParquetReader, SerReader};
 
     #[test]
     fn firmware_trace_is_only_requested_when_enabled() {
@@ -1276,5 +1668,201 @@ mod tests {
         let protocol_only = pd_timeline_entries(&protocol_log, &trace_log, true, false);
         assert_eq!(protocol_only.len(), 1);
         assert!(matches!(protocol_only[0], PdTimelineEntry::Protocol(_)));
+    }
+
+    #[test]
+    fn downloaded_offline_log_becomes_the_active_plot_source() {
+        let (usb_tx, usb_rx) = mpsc::unbounded_channel();
+        let (cmd_tx, _cmd_rx) = mpsc::unbounded_channel();
+        let mut app = PowerMonitorApp::new(usb_rx, cmd_tx);
+        app.plot_metrics[0] = PlotMetric::Cc1;
+        let fixture = captured_test_view();
+
+        usb_tx
+            .send(UsbMessage::OfflineLogDownloaded(fixture.log.as_ref().clone()))
+            .unwrap();
+        app.process_messages();
+
+        assert_eq!(app.plot_source, PlotSource::Offline);
+        assert_eq!(app.time_window, TimeWindow::All);
+        assert_eq!(app.plot_metrics[0], PlotMetric::Voltage);
+        assert_eq!(app.offline_view.as_ref().unwrap().samples.len(), 3);
+        assert!(!app.offline_busy);
+    }
+
+    #[test]
+    fn empty_offline_catalog_clears_selection() {
+        let (usb_tx, usb_rx) = mpsc::unbounded_channel();
+        let (cmd_tx, _cmd_rx) = mpsc::unbounded_channel();
+        let mut app = PowerMonitorApp::new(usb_rx, cmd_tx);
+        app.offline_selected = Some(2);
+
+        usb_tx.send(UsbMessage::OfflineCatalog(Vec::new())).unwrap();
+        app.process_messages();
+
+        assert!(app.offline_catalog.is_empty());
+        assert_eq!(app.offline_selected, None);
+        assert!(app.offline_status.contains("No offline recordings"));
+    }
+
+    #[test]
+    #[ignore = "requires a connected KM003C"]
+    fn hardware_offline_flow_pauses_and_resumes_streaming() {
+        tokio::runtime::Runtime::new().unwrap().block_on(async {
+            let (usb_tx, mut usb_rx) = mpsc::unbounded_channel();
+            let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+            let task = tokio::spawn(usb_streaming_task(usb_tx, cmd_rx));
+            cmd_tx.send(UsbCommand::Connect(GraphSampleRate::Sps50, false)).unwrap();
+
+            let startup_deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+            let mut device_state = None;
+            let mut streaming = false;
+            while !(device_state.is_some() && streaming) {
+                let message = tokio::time::timeout_at(startup_deadline, usb_rx.recv())
+                    .await
+                    .expect("device did not connect before the deadline")
+                    .expect("USB task exited during connection");
+                match message {
+                    UsbMessage::Connected(state) => device_state = Some(state),
+                    UsbMessage::StreamingStarted(GraphSampleRate::Sps50) => streaming = true,
+                    _ => {}
+                }
+            }
+
+            cmd_tx.send(UsbCommand::RequestOfflineCatalog).unwrap();
+            let operation_deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+            let mut stopped = false;
+            let catalog = loop {
+                let message = tokio::time::timeout_at(operation_deadline, usb_rx.recv())
+                    .await
+                    .expect("offline catalog request did not finish before the deadline")
+                    .expect("USB task exited during offline catalog request");
+                match message {
+                    UsbMessage::StreamingStopped => stopped = true,
+                    UsbMessage::OfflineCatalog(catalog) => {
+                        assert!(stopped, "catalog arrived before streaming was paused");
+                        break catalog;
+                    }
+                    UsbMessage::OfflineOperationFailed(error) => panic!("offline catalog failed: {error}"),
+                    _ => {}
+                }
+            };
+            loop {
+                let message = tokio::time::timeout_at(operation_deadline, usb_rx.recv())
+                    .await
+                    .expect("streaming did not resume after catalog request")
+                    .expect("USB task exited before streaming resumed");
+                if matches!(message, UsbMessage::StreamingStarted(GraphSampleRate::Sps50)) {
+                    break;
+                }
+            }
+
+            let mut downloaded_log = None;
+            if let Some(metadata) = catalog.first().cloned() {
+                cmd_tx.send(UsbCommand::DownloadOfflineLog(metadata.clone())).unwrap();
+                let download_deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+                let mut stopped = false;
+                let mut downloaded = false;
+                let mut resumed = false;
+                while !(downloaded && resumed) {
+                    let message = tokio::time::timeout_at(download_deadline, usb_rx.recv())
+                        .await
+                        .expect("offline download did not finish before the deadline")
+                        .expect("USB task exited during offline download");
+                    match message {
+                        UsbMessage::StreamingStopped => stopped = true,
+                        UsbMessage::OfflineLogDownloaded(log) => {
+                            assert!(stopped, "offline log arrived before streaming was paused");
+                            assert_eq!(log.metadata, metadata);
+                            assert_eq!(log.samples.len(), usize::from(metadata.sample_count));
+                            downloaded_log = Some(log);
+                            downloaded = true;
+                        }
+                        UsbMessage::StreamingStarted(GraphSampleRate::Sps50) => resumed = true,
+                        UsbMessage::OfflineOperationFailed(error) => panic!("offline download failed: {error}"),
+                        _ => {}
+                    }
+                }
+            }
+
+            cmd_tx.send(UsbCommand::Disconnect).unwrap();
+            drop(cmd_tx);
+            let _ = tokio::time::timeout(Duration::from_secs(5), task)
+                .await
+                .expect("USB task did not stop after disconnect");
+
+            if let Some(log) = downloaded_log {
+                let device_state = device_state.expect("connected device state was not retained");
+                let recording_metadata = RecordingMetadata {
+                    model: device_state.info.model.clone(),
+                    firmware: device_state.info.fw_version.clone(),
+                    serial: device_state.info.serial_id.clone(),
+                };
+                let expected_rows = log.samples.len();
+                let expected_charge_uah = log
+                    .metadata
+                    .final_charge
+                    .get::<km003c_lib::uom::si::electric_charge::microampere_hour>();
+                let expected_energy_uwh = log
+                    .metadata
+                    .final_energy
+                    .get::<km003c_lib::uom::si::energy::microwatt_hour>();
+                let view = Arc::new(OfflineRecordingView::new(log));
+                assert_eq!(view.samples.last().unwrap().charge_uah, expected_charge_uah);
+                assert_eq!(view.samples.last().unwrap().energy_uwh, expected_energy_uwh);
+
+                for format in RecordingFormat::ALL {
+                    let path = std::env::temp_dir().join(format!(
+                        "km003c-egui-hardware-offline-{}.{}",
+                        std::process::id(),
+                        format.extension()
+                    ));
+                    let mut export =
+                        OfflineExportTask::start(path.clone(), format, recording_metadata.clone(), Arc::clone(&view))
+                            .unwrap();
+                    let export_deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+                    let rows = loop {
+                        match export.poll_event() {
+                            Some(OfflineExportEvent::Finished { rows, .. }) => break rows,
+                            Some(OfflineExportEvent::Failed(error)) => panic!("offline export failed: {error}"),
+                            None => {
+                                assert!(
+                                    tokio::time::Instant::now() < export_deadline,
+                                    "offline export did not finish before the deadline"
+                                );
+                                tokio::time::sleep(Duration::from_millis(10)).await;
+                            }
+                        }
+                    };
+                    assert_eq!(rows, expected_rows);
+                    let dataframe = match format {
+                        RecordingFormat::Parquet => ParquetReader::new(std::fs::File::open(&path).unwrap())
+                            .finish()
+                            .unwrap(),
+                        RecordingFormat::Csv => CsvReader::new(std::fs::File::open(&path).unwrap()).finish().unwrap(),
+                    };
+                    assert_eq!(dataframe.shape(), (expected_rows, 23));
+                    assert_eq!(
+                        dataframe
+                            .column("charge_uah")
+                            .unwrap()
+                            .f64()
+                            .unwrap()
+                            .get(expected_rows - 1),
+                        Some(expected_charge_uah)
+                    );
+                    assert_eq!(
+                        dataframe
+                            .column("energy_uwh")
+                            .unwrap()
+                            .f64()
+                            .unwrap()
+                            .get(expected_rows - 1),
+                        Some(expected_energy_uwh)
+                    );
+                    std::fs::remove_file(path).unwrap();
+                }
+            }
+        });
     }
 }

--- a/km003c-egui/src/measurement.rs
+++ b/km003c-egui/src/measurement.rs
@@ -201,6 +201,10 @@ impl PlotMetric {
         }
     }
 
+    pub(crate) const fn supports_offline(self) -> bool {
+        !matches!(self, Self::Cc1 | Self::Cc2 | Self::DPlus | Self::DMinus)
+    }
+
     pub(crate) const fn unit(self) -> &'static str {
         match self {
             Self::Voltage | Self::Cc1 | Self::Cc2 | Self::DPlus | Self::DMinus => "V",

--- a/km003c-egui/src/offline_export.rs
+++ b/km003c-egui/src/offline_export.rs
@@ -1,0 +1,254 @@
+use std::error::Error;
+use std::fs::File;
+use std::io::BufWriter;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::mpsc::{self, Receiver, TryRecvError};
+use std::thread::{self, JoinHandle};
+
+use polars::df;
+use polars::prelude::{CsvWriter, DataFrame, KeyValueMetadata, ParquetWriter, SerWriter};
+
+use crate::offline_view::OfflineRecordingView;
+use crate::recording::{RECORDING_SCHEMA_VERSION, RecordingFormat, RecordingMetadata};
+
+const ROW_GROUP_SIZE: usize = 8_192;
+
+#[derive(Debug)]
+pub(crate) enum OfflineExportEvent {
+    Finished { path: PathBuf, rows: usize },
+    Failed(String),
+}
+
+pub(crate) struct OfflineExportTask {
+    event_rx: Receiver<OfflineExportEvent>,
+    handle: Option<JoinHandle<()>>,
+    pub(crate) path: PathBuf,
+}
+
+impl OfflineExportTask {
+    pub(crate) fn start(
+        path: PathBuf,
+        format: RecordingFormat,
+        device: RecordingMetadata,
+        view: Arc<OfflineRecordingView>,
+    ) -> Result<Self, String> {
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        if !parent.exists() {
+            return Err(format!("output directory does not exist: {}", parent.display()));
+        }
+
+        let partial_path = partial_path(&path);
+        let final_path = path.clone();
+        let (event_tx, event_rx) = mpsc::channel();
+        let handle = thread::Builder::new()
+            .name("km003c-offline-export".to_string())
+            .spawn(move || {
+                let rows = view.samples.len();
+                let result = write_offline_file(&partial_path, format, &device, &view).and_then(|()| {
+                    replace_file(&partial_path, &final_path)?;
+                    Ok(())
+                });
+                let event = match result {
+                    Ok(()) => OfflineExportEvent::Finished { path: final_path, rows },
+                    Err(error) => OfflineExportEvent::Failed(format!(
+                        "{error}; incomplete export remains at {}",
+                        partial_path.display()
+                    )),
+                };
+                let _ = event_tx.send(event);
+            })
+            .map_err(|error| format!("failed to start offline export thread: {error}"))?;
+        Ok(Self {
+            event_rx,
+            handle: Some(handle),
+            path,
+        })
+    }
+
+    pub(crate) fn poll_event(&mut self) -> Option<OfflineExportEvent> {
+        match self.event_rx.try_recv() {
+            Ok(event) => {
+                if let Some(handle) = self.handle.take() {
+                    let _ = handle.join();
+                }
+                Some(event)
+            }
+            Err(TryRecvError::Empty) => None,
+            Err(TryRecvError::Disconnected) => Some(OfflineExportEvent::Failed(
+                "offline export thread exited without reporting a result".to_string(),
+            )),
+        }
+    }
+}
+
+impl Drop for OfflineExportTask {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn write_offline_file(
+    path: &Path,
+    format: RecordingFormat,
+    device: &RecordingMetadata,
+    view: &OfflineRecordingView,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let file = File::create(path)?;
+    let mut dataframe = offline_to_dataframe(view)?;
+    match format {
+        RecordingFormat::Parquet => {
+            let metadata = KeyValueMetadata::from_static(vec![
+                (
+                    "km003c.schema_version".to_string(),
+                    RECORDING_SCHEMA_VERSION.to_string(),
+                ),
+                ("km003c.source".to_string(), "offline".to_string()),
+                ("km003c.accumulator_source".to_string(), "device".to_string()),
+                ("km003c.model".to_string(), device.model.clone()),
+                ("km003c.firmware".to_string(), device.firmware.clone()),
+                ("km003c.serial".to_string(), device.serial.clone()),
+                (
+                    "km003c.offline.filename".to_string(),
+                    view.log.metadata.filename_lossy().into_owned(),
+                ),
+                (
+                    "km003c.offline.interval_us".to_string(),
+                    view.log
+                        .metadata
+                        .interval
+                        .get::<km003c_lib::uom::si::time::microsecond>()
+                        .round()
+                        .to_string(),
+                ),
+                (
+                    "km003c.offline.flags".to_string(),
+                    format!("0x{:04x}", view.log.metadata.flags),
+                ),
+            ]);
+            ParquetWriter::new(BufWriter::new(file))
+                .with_key_value_metadata(Some(metadata))
+                .with_row_group_size(Some(ROW_GROUP_SIZE))
+                .finish(&mut dataframe)?;
+        }
+        RecordingFormat::Csv => {
+            CsvWriter::new(BufWriter::new(file)).finish(&mut dataframe)?;
+        }
+    }
+    Ok(())
+}
+
+fn offline_to_dataframe(view: &OfflineRecordingView) -> Result<DataFrame, polars::error::PolarsError> {
+    let rows = &view.samples;
+    let unavailable_u32 = vec![None::<u32>; rows.len()];
+    let unavailable_u64 = vec![None::<u64>; rows.len()];
+    let unavailable_i64 = vec![None::<i64>; rows.len()];
+    let unavailable_bool = vec![None::<bool>; rows.len()];
+    df!(
+        "elapsed_us" => rows.iter().map(|row| row.elapsed_us).collect::<Vec<_>>(),
+        "sample_index" => rows.iter().map(|row| row.sample_index).collect::<Vec<_>>(),
+        "sequence" => unavailable_u32.clone(),
+        "marker" => unavailable_u32.clone(),
+        "sample_rate_hz" => unavailable_u32.clone(),
+        "missing_samples" => unavailable_u32.clone(),
+        "gap_duration_us" => unavailable_u64.clone(),
+        "interpolated" => unavailable_bool,
+        "cumulative_missing_samples" => unavailable_u64.clone(),
+        "cumulative_interpolated_duration_us" => unavailable_u64,
+        "discarded_sequence_samples" => unavailable_u32,
+        "cumulative_discarded_sequence_samples" => vec![None::<u64>; rows.len()],
+        "vbus_uv" => rows.iter().map(|row| row.vbus_uv).collect::<Vec<_>>(),
+        "ibus_ua" => rows.iter().map(|row| row.ibus_ua).collect::<Vec<_>>(),
+        "power_uw" => rows.iter().map(|row| row.power_uw).collect::<Vec<_>>(),
+        "charge_uah" => rows.iter().map(|row| row.charge_uah).collect::<Vec<_>>(),
+        "energy_uwh" => rows.iter().map(|row| row.energy_uwh).collect::<Vec<_>>(),
+        "charge_throughput_uah" => rows.iter().map(|row| row.charge_throughput_uah).collect::<Vec<_>>(),
+        "energy_throughput_uwh" => rows.iter().map(|row| row.energy_throughput_uwh).collect::<Vec<_>>(),
+        "cc1_uv" => unavailable_i64.clone(),
+        "cc2_uv" => unavailable_i64.clone(),
+        "dp_uv" => unavailable_i64.clone(),
+        "dm_uv" => unavailable_i64,
+    )
+}
+
+fn partial_path(path: &Path) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(".partial");
+    PathBuf::from(name)
+}
+
+fn replace_file(partial: &Path, final_path: &Path) -> std::io::Result<()> {
+    if final_path.exists() {
+        std::fs::remove_file(final_path)?;
+    }
+    std::fs::rename(partial, final_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::offline_view::captured_test_view;
+    use polars::prelude::{CsvReader, ParquetReader, SerReader};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_TEST_FILE: AtomicU64 = AtomicU64::new(0);
+
+    fn test_path(extension: &str) -> PathBuf {
+        let sequence = NEXT_TEST_FILE.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "km003c-egui-offline-export-{}-{sequence}.{extension}",
+            std::process::id()
+        ))
+    }
+
+    fn test_metadata() -> RecordingMetadata {
+        RecordingMetadata {
+            model: "KM003C".to_string(),
+            firmware: "1.9.9".to_string(),
+            serial: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn dataframe_preserves_values_and_marks_unavailable_channels_null() {
+        let view = captured_test_view();
+        let dataframe = offline_to_dataframe(&view).unwrap();
+
+        assert_eq!(dataframe.shape(), (3, 23));
+        assert_eq!(dataframe.column("sequence").unwrap().null_count(), 3);
+        assert_eq!(dataframe.column("cc1_uv").unwrap().null_count(), 3);
+        assert_eq!(
+            dataframe.column("vbus_uv").unwrap().i64().unwrap().get(0),
+            Some(4_999_553)
+        );
+        assert_eq!(
+            dataframe.column("energy_throughput_uwh").unwrap().f64().unwrap().get(2),
+            Some(5_747_232.0)
+        );
+    }
+
+    #[test]
+    fn parquet_and_csv_exports_are_readable() {
+        let view = captured_test_view();
+        let metadata = test_metadata();
+
+        let parquet_path = test_path("parquet");
+        write_offline_file(&parquet_path, RecordingFormat::Parquet, &metadata, &view).unwrap();
+        let parquet = ParquetReader::new(File::open(&parquet_path).unwrap()).finish().unwrap();
+        assert_eq!(parquet.shape(), (3, 23));
+        assert_eq!(parquet.column("sequence").unwrap().null_count(), 3);
+        std::fs::remove_file(parquet_path).unwrap();
+
+        let csv_path = test_path("csv");
+        write_offline_file(&csv_path, RecordingFormat::Csv, &metadata, &view).unwrap();
+        let csv = CsvReader::new(File::open(&csv_path).unwrap()).finish().unwrap();
+        assert_eq!(csv.shape(), (3, 23));
+        assert_eq!(
+            csv.column("charge_uah").unwrap().f64().unwrap().get(2),
+            Some(-810_335.0)
+        );
+        std::fs::remove_file(csv_path).unwrap();
+    }
+}

--- a/km003c-egui/src/offline_view.rs
+++ b/km003c-egui/src/offline_view.rs
@@ -1,0 +1,160 @@
+use std::sync::Arc;
+
+use km003c_lib::uom::si::power::microwatt;
+use km003c_lib::{OfflineLog, OfflineLogSample};
+
+use crate::measurement::PlotMetric;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct OfflineViewSample {
+    pub(crate) elapsed_us: u64,
+    pub(crate) sample_index: u64,
+    pub(crate) vbus_uv: i64,
+    pub(crate) ibus_ua: i64,
+    pub(crate) power_uw: i64,
+    pub(crate) charge_uah: f64,
+    pub(crate) energy_uwh: f64,
+    pub(crate) charge_throughput_uah: f64,
+    pub(crate) energy_throughput_uwh: f64,
+}
+
+impl OfflineViewSample {
+    pub(crate) fn elapsed_seconds(self) -> f64 {
+        self.elapsed_us as f64 / 1_000_000.0
+    }
+
+    pub(crate) fn metric_value(self, metric: PlotMetric) -> Option<f64> {
+        match metric {
+            PlotMetric::Voltage => Some(self.vbus_uv as f64 / 1_000_000.0),
+            PlotMetric::Current => Some((self.ibus_ua as f64 / 1_000_000.0).abs()),
+            PlotMetric::SignedCurrent => Some(self.ibus_ua as f64 / 1_000_000.0),
+            PlotMetric::Power => Some((self.power_uw as f64 / 1_000_000.0).abs()),
+            PlotMetric::SignedPower => Some(self.power_uw as f64 / 1_000_000.0),
+            PlotMetric::Charge => Some(self.charge_throughput_uah / 1_000.0),
+            PlotMetric::SignedCharge => Some(self.charge_uah / 1_000.0),
+            PlotMetric::Energy => Some(self.energy_throughput_uwh / 1_000.0),
+            PlotMetric::SignedEnergy => Some(self.energy_uwh / 1_000.0),
+            PlotMetric::Cc1 | PlotMetric::Cc2 | PlotMetric::DPlus | PlotMetric::DMinus => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct OfflineRecordingView {
+    pub(crate) log: Arc<OfflineLog>,
+    pub(crate) samples: Vec<OfflineViewSample>,
+}
+
+impl OfflineRecordingView {
+    pub(crate) fn new(log: OfflineLog) -> Self {
+        let log = Arc::new(log);
+        let interval_us = (log.metadata.interval.get::<km003c_lib::uom::si::time::microsecond>()).round() as u64;
+        let mut previous_charge_uah = 0_i32;
+        let mut previous_energy_uwh = 0_i32;
+        let mut charge_throughput_uah = 0_u64;
+        let mut energy_throughput_uwh = 0_u64;
+        let samples = log
+            .samples
+            .iter()
+            .enumerate()
+            .map(|(index, sample)| {
+                let raw = sample.raw();
+                charge_throughput_uah =
+                    charge_throughput_uah.saturating_add(u64::from(raw.charge_uah.abs_diff(previous_charge_uah)));
+                energy_throughput_uwh =
+                    energy_throughput_uwh.saturating_add(u64::from(raw.energy_uwh.abs_diff(previous_energy_uwh)));
+                previous_charge_uah = raw.charge_uah;
+                previous_energy_uwh = raw.energy_uwh;
+                decode_sample(sample, index, interval_us, charge_throughput_uah, energy_throughput_uwh)
+            })
+            .collect();
+        Self { log, samples }
+    }
+}
+
+fn decode_sample(
+    sample: &OfflineLogSample,
+    index: usize,
+    interval_us: u64,
+    charge_throughput_uah: u64,
+    energy_throughput_uwh: u64,
+) -> OfflineViewSample {
+    let raw = sample.raw();
+    OfflineViewSample {
+        elapsed_us: (index as u64).saturating_mul(interval_us),
+        sample_index: index as u64,
+        vbus_uv: i64::from(raw.voltage_uv),
+        ibus_ua: i64::from(raw.current_ua),
+        power_uw: sample.power.get::<microwatt>().round() as i64,
+        charge_uah: f64::from(raw.charge_uah),
+        energy_uwh: f64::from(raw.energy_uwh),
+        charge_throughput_uah: charge_throughput_uah as f64,
+        energy_throughput_uwh: energy_throughput_uwh as f64,
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn captured_test_view() -> OfflineRecordingView {
+    use km003c_lib::LogMetadata;
+    use km003c_lib::uom::si::electric_charge::microampere_hour;
+    use km003c_lib::uom::si::energy::microwatt_hour;
+    use km003c_lib::uom::si::f64::{ElectricCharge, Energy, Time};
+    use km003c_lib::uom::si::time::{millisecond, second};
+
+    let bytes = [
+        "81494c0021f0e2ff56ebffffb998ffff",
+        "bcaa89006e25f2ff2dd5f8fff7fdd6ff",
+        "cf2a8900947dfeffa1a2f3ffe04da8ff",
+    ]
+    .into_iter()
+    .flat_map(|sample| hex::decode(sample).unwrap())
+    .collect::<Vec<_>>();
+    let mut filename_raw = [0; 16];
+    filename_raw[..5].copy_from_slice(b"A01.d");
+    OfflineRecordingView::new(
+        OfflineLog::from_bytes(
+            LogMetadata {
+                filename_raw,
+                unknown_0x10: 0x0a45,
+                sample_count: 3,
+                interval: Time::new::<millisecond>(10_000.0),
+                flags: 0,
+                recorded_duration: Time::new::<second>(20.0),
+                final_charge: ElectricCharge::new::<microampere_hour>(-810_335.0),
+                final_energy: Energy::new::<microwatt_hour>(-5_747_232.0),
+                data_offset: 0,
+                reserved_tail: [0; 8],
+            },
+            &bytes,
+        )
+        .unwrap(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_captured_samples_without_inventing_auxiliary_channels() {
+        let view = captured_test_view();
+
+        assert_eq!(view.samples.len(), 3);
+        assert_eq!(view.samples[1].elapsed_us, 10_000_000);
+        assert_eq!(view.samples[0].vbus_uv, 4_999_553);
+        assert_eq!(view.samples[0].ibus_ua, -1_904_607);
+        assert_eq!(view.samples[0].charge_throughput_uah, 5_290.0);
+        assert_eq!(view.samples[2].charge_throughput_uah, 810_335.0);
+        assert!(view.samples[0].metric_value(PlotMetric::Cc1).is_none());
+    }
+
+    #[test]
+    fn throughput_accumulates_absolute_device_counter_changes() {
+        let view = captured_test_view();
+
+        assert_eq!(view.samples[0].energy_throughput_uwh, 26_439.0);
+        assert_eq!(view.samples[2].energy_throughput_uwh, 5_747_232.0);
+        assert_eq!(view.samples[2].metric_value(PlotMetric::Energy), Some(5_747.232));
+        assert_eq!(view.samples[2].metric_value(PlotMetric::SignedEnergy), Some(-5_747.232));
+    }
+}

--- a/km003c-egui/src/recording.rs
+++ b/km003c-egui/src/recording.rs
@@ -9,8 +9,7 @@ use polars::df;
 use polars::prelude::{CsvWriter, DataFrame, KeyValueMetadata, ParquetWriter, SerWriter};
 
 use crate::measurement::MeasurementSample;
-
-const RECORDING_SCHEMA_VERSION: &str = "1";
+pub(crate) const RECORDING_SCHEMA_VERSION: &str = "1";
 const ROW_GROUP_SIZE: usize = 8_192;
 const CHANNEL_CAPACITY: usize = 32;
 


### PR DESCRIPTION
## Summary

- add an **Offline Recordings** browser for the catalog stored on the KM003C
- pause AdcQueue streaming while loading metadata or downloading a recording, then restore it at the selected rate
- plot downloaded voltage, signed/absolute current and power, and signed/throughput charge and energy in the existing three configurable plots
- export downloaded recordings to Parquet or CSV with the same 23-column schema as live captures
- keep unavailable offline-only fields null instead of fabricating values

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +1.97.0 check --workspace --all-targets --all-features`
- `cargo fmt --all`
- `git diff --check`
- connected KM003C firmware 1.9.9: repeatedly verified pause → catalog → download → resume at 50 SPS
- downloaded real `A01.d`: 71 samples at 10-second intervals, matching 700-second duration
- verified the final downloaded sample matches the catalog accumulators: −30,381 µAh and −255,882 µWh
- exported the real download to both Parquet and CSV, read both back with Polars, and verified 71 rows, 23 columns, and final accumulators
- captured fixtures additionally cover exact sample decoding, signed/throughput values, unavailable fields, and both export formats